### PR TITLE
Backends/cruxmir

### DIFF
--- a/compatibility-test/Cargo.toml
+++ b/compatibility-test/Cargo.toml
@@ -8,14 +8,9 @@ authors = [
 edition = "2018"
 description = "Tests for both the propverify and the proptest crates - to check compatibility."
 
-[dependencies]
-
-[target.'cfg(verify)'.dependencies]
-propverify = { path="../propverify" }
-
-[target.'cfg(not(verify))'.dependencies]
-proptest = { version = "*" }
-
 [features]
-verifier-crux = ["propverify/verifier-crux"]
-verifier-klee = ["propverify/verifier-klee"]
+verify = [ "propverify" ]
+
+[dependencies]
+propverify = { path="../propverify", optional=true }
+proptest = { version = "*", optional=true }

--- a/compatibility-test/Cargo.toml
+++ b/compatibility-test/Cargo.toml
@@ -17,4 +17,5 @@ propverify = { path="../propverify" }
 proptest = { version = "*" }
 
 [features]
+verifier-crux = ["propverify/verifier-crux"]
 verifier-klee = ["propverify/verifier-klee"]

--- a/compatibility-test/src/collections.rs
+++ b/compatibility-test/src/collections.rs
@@ -11,9 +11,9 @@
 // Proptest-based tests to check collection support
 ////////////////////////////////////////////////////////////////
 
-#[cfg(not(verify))]
+#[cfg(not(feature = "verify"))]
 use proptest::prelude::*;
-#[cfg(verify)]
+#[cfg(feature = "verify")]
 use propverify::prelude::*;
 
 

--- a/compatibility-test/src/compose.rs
+++ b/compatibility-test/src/compose.rs
@@ -11,9 +11,9 @@
 // Proptest-based tests exploring how to use prop_compose
 ////////////////////////////////////////////////////////////////
 
-#[cfg(not(verify))]
+#[cfg(not(feature = "verify"))]
 use proptest::prelude::*;
-#[cfg(verify)]
+#[cfg(feature = "verify")]
 use propverify::prelude::*;
 
 #[cfg(test)]

--- a/compatibility-test/src/dynamic.rs
+++ b/compatibility-test/src/dynamic.rs
@@ -12,9 +12,9 @@
 // trait objects
 ////////////////////////////////////////////////////////////////
 
-#[cfg(not(verify))]
+#[cfg(not(feature = "verify"))]
 use proptest::prelude::*;
-#[cfg(verify)]
+#[cfg(feature = "verify")]
 use propverify::prelude::*;
 
 

--- a/compatibility-test/src/enumeration.rs
+++ b/compatibility-test/src/enumeration.rs
@@ -12,9 +12,9 @@
 // enumerations
 ////////////////////////////////////////////////////////////////
 
-#[cfg(not(verify))]
+#[cfg(not(feature = "verify"))]
 use proptest::prelude::*;
-#[cfg(verify)]
+#[cfg(feature = "verify")]
 use propverify::prelude::*;
 
 

--- a/compatibility-test/src/main.rs
+++ b/compatibility-test/src/main.rs
@@ -16,9 +16,9 @@
 
 #![allow(unused_imports)]
 
-#[cfg(not(verify))]
+#[cfg(not(feature = "verify"))]
 use proptest::prelude::*;
-#[cfg(verify)]
+#[cfg(feature = "verify")]
 use propverify::prelude::*;
 
 mod collections;
@@ -28,6 +28,7 @@ mod enumeration;
 
 // A simple test of the propverify/proptest library
 proptest! {
+    #[test]
     fn main(
         a in 4..8u32,
         b in 5..9u32)

--- a/docs/install-crux.md
+++ b/docs/install-crux.md
@@ -1,0 +1,94 @@
+# Installation
+
+The best way to install crux (aka mir-verifier) is to follow the instructions on
+[crux's GitHub page](https://github.com/GaloisInc/mir-verifier).
+
+For convenience, instructions for installing crux and its dependencies are
+provided below.
+
+
+We are going to install Haskell, Rust, mir-json, Yices and crux.
+
+Where possible `apt` is used. 
+Everything else is installed under `$HOME`.
+
+
+### Installing Haskell
+
+``` shell
+sudo apt install cabal-install ghc
+cabal new-update
+```
+
+Make sure `PATH` includes `$HOME/.cabal/bin`.
+
+
+### Installing Rust
+
+Install rust using rustup.
+mir-json requires nightly-2020-03-22 so we will get that.
+
+``` shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install nightly-2020-03-22 --force
+rustup default nightly-2020-03-22
+rustup component add --toolchain nightly-2020-03-22 rustc-dev
+```
+
+Make sure `PATH` includes `$HOME/.cargo/bin`.
+
+### Install mir-json
+
+``` shell
+git clone git@github.com:GaloisInc/mir-json.git
+cd mir-json
+RUSTC_WRAPPER=./rustc-rpath.sh cargo install --locked
+```
+
+### Install Yices
+
+``` shell
+git clone git@github.com:SRI-CSL/yices2.git
+cd yices2
+autoconf
+./configure --prefix="$HOME/.local"
+make
+make install
+```
+
+Make sure `PATH` includes `$HOME/.local/bin`
+
+### Building Crux
+
+``` shell
+git clone git@github.com:GaloisInc/mir-verifier.git
+cd mir-verifier
+git submodule update --init
+cabal v2-build
+./translate_libs.sh
+cabal v2-install crux-mir
+```
+
+### Shell init script
+
+Add the following lines to your shell init script (assuming crux was cloned into
+`$HOME/mir-verifier`).
+
+``` shell
+export PATH=$HOME/.local/bin:$HOME/.cabal/bin:$HOME/.cargo/bin:$PATH
+export CRUX_RUST_LIBRARY_PATH=$HOME/mir-verifier/rlibs
+```
+### Testing
+
+Run crux's test suite:
+
+``` shell
+cd mir-verifier
+cabal v2-test
+# [...]
+# All 254 tests passed (322.16s)
+# Test suite test: PASS
+# Test suite logged to:
+# [...]
+# 1 of 1 test suites (1 of 1 test cases) passed.
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,4 +10,4 @@ Follow the following steps in order
 
 - [Installing the Rust compiler]
 - [Installing KLEE's and its dependencies](klee-annotations/docs/installation.md)
-
+- [Installing crux and its dependencies](install-crux.md)

--- a/propverify/Cargo.toml
+++ b/propverify/Cargo.toml
@@ -13,14 +13,16 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [features]
-
-default = ["verifier-klee"]
+# These features are mutually exclusive
+meta   = ["verification-annotations/verifier-std"] # running to extract meta data
+verify = [] # running a verifier
 
 # support for floating point
 float = []
 
-verifier-crux = [ "verification-annotations/verifier-crux" ]
-verifier-klee = [ "verification-annotations/verifier-klee", "float" ]
+verifier-crux = [ "verify", "verification-annotations/verifier-crux" ]
+verifier-klee = [ "verify", "verification-annotations/verifier-klee", "float" ]
+verifier-std  = [ "verify", "verification-annotations/verifier-std", "float" ]
 
 [dependencies]
 verification-annotations = { path = "../verification-annotations" }

--- a/propverify/Cargo.toml
+++ b/propverify/Cargo.toml
@@ -16,7 +16,11 @@ readme = "README.md"
 
 default = ["verifier-klee"]
 
-verifier-klee = [ "verification-annotations/verifier-klee" ]
+# support for floating point
+float = []
+
+verifier-crux = [ "verification-annotations/verifier-crux" ]
+verifier-klee = [ "verification-annotations/verifier-klee", "float" ]
 
 [dependencies]
 verification-annotations = { path = "../verification-annotations" }

--- a/propverify/src/lib.rs
+++ b/propverify/src/lib.rs
@@ -45,6 +45,7 @@ pub mod prelude {
         pub mod num {
             pub use crate::strategy::{i128, i16, i32, i64, i8, isize};
             pub use crate::strategy::{u128, u16, u32, u64, u8, usize};
+            #[cfg(feature = "float")]
             pub use crate::strategy::{f32, f64};
         }
     }

--- a/propverify/src/strategy.rs
+++ b/propverify/src/strategy.rs
@@ -522,6 +522,7 @@ numeric_api! {
     isize;
 }
 
+#[cfg(feature = "float")]
 numeric_api! {
     f32;
     f64;

--- a/verification-annotations/Cargo.toml
+++ b/verification-annotations/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["klee", "crux", "mir", "verification", "testing"]
 license = "MIT OR Apache-2.0"
 
 [features]
-
 verifier-crux = []
 verifier-klee = []
+verifier-std  = []
 
 [dependencies]

--- a/verification-annotations/Cargo.toml
+++ b/verification-annotations/Cargo.toml
@@ -8,11 +8,12 @@ authors = [
 edition = "2018"
 description = "verification annotation library"
 categories = ["development-tools::testing"]
-keywords = ["klee", "mir", "verification", "testing"]
+keywords = ["klee", "crux", "mir", "verification", "testing"]
 license = "MIT OR Apache-2.0"
 
 [features]
 
+verifier-crux = []
 verifier-klee = []
 
 [dependencies]

--- a/verification-annotations/src/crux.rs
+++ b/verification-annotations/src/crux.rs
@@ -1,0 +1,93 @@
+// Copyright 2020 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/////////////////////////////////////////////////////////////////
+// FFI wrapper for Crux-mir static simulator tool
+/////////////////////////////////////////////////////////////////
+
+#[cfg(crux)]
+extern crate crucible;
+
+// pub mod crucible::symbolic;
+// pub use self::symbolic::Symbolic;
+
+// Create an abstract value of type <T>
+//
+// This should only be used on types that occupy contiguous memory
+// and where all possible bit-patterns are legal.
+// e.g., u8/i8, ... u128/i128, f32/f64
+pub fn abstract_value<T: crucible::Symbolic>() -> T {
+    T::symbolic(concat!("symb_", line!(), "_", column!()))
+}
+
+// Add an assumption
+pub fn assume(cond: bool) {
+    crucible::crucible_assume!(cond)
+}
+
+// Reject the current execution with a verification failure.
+//
+// In almost all circumstances, report_error should
+// be used instead because it generates an error message.
+pub fn abort() {
+    crucible::crucible_assert!(false)
+}
+
+// Reject the current execution path with a verification success.
+// This is equivalent to assume(false)
+// and the opposite of report_error.
+//
+// Typical usage is in generating symbolic values when the value
+// does not meet some criteria.
+pub fn reject() -> ! {
+    crucible::crucible_assume!(false);
+    panic!("should have been rejected!");
+}
+
+// Detect whether the program is being run symbolically in KLEE
+// or being replayed using the kleeRuntest runtime.
+//
+// This is used to decide whether to display the values of
+// variables that may be either symbolic or concrete.
+pub fn is_replay() -> bool {
+    false
+}
+
+// Reject the current execution with a verification failure
+// and an error message.
+pub fn report_error(message: &str) {
+    // Mimic the format of klee_report_error
+    // (We don't use klee_report_error because it is not
+    // supported by the kleeRuntest library.)
+    eprintln!("KLEE: ERROR:{}", message);
+    abort();
+}
+
+// Check an assertion
+pub fn verify(cond: bool) {
+    if !cond {
+        report_error("verification failed");
+    }
+}
+
+// Declare that failure is the expected behaviour
+pub fn expect_raw(msg: &str) {
+    println!("VERIFIER_EXPECT: {}", msg)
+}
+
+// Declare that failure is the expected behaviour
+pub fn expect(msg: Option<&str>) {
+    match msg {
+        None => println!("VERIFIER_EXPECT: should_panic"),
+        Some(msg) => println!("VERIFIER_EXPECT: should_panic(expected = \"{}\")", msg)
+    }
+}
+
+/////////////////////////////////////////////////////////////////
+// End
+/////////////////////////////////////////////////////////////////

--- a/verification-annotations/src/lib.rs
+++ b/verification-annotations/src/lib.rs
@@ -16,6 +16,11 @@ mod klee;
 #[cfg(feature = "verifier-klee")]
 pub use crate::klee::*;
 
+#[cfg(feature = "verifier-std")]
+mod verifier_std;
+#[cfg(feature = "verifier-std")]
+pub use crate::verifier_std::*;
+
 // At the moment, the cargo-verify script does not support
 // use of a separate test directory so, for now, we put
 // the tests here.

--- a/verification-annotations/src/lib.rs
+++ b/verification-annotations/src/lib.rs
@@ -6,6 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "verifier-crux")]
+mod crux;
+#[cfg(feature = "verifier-crux")]
+pub use crate::crux::*;
+
 #[cfg(feature = "verifier-klee")]
 mod klee;
 #[cfg(feature = "verifier-klee")]

--- a/verification-annotations/src/verifier_std.rs
+++ b/verification-annotations/src/verifier_std.rs
@@ -1,0 +1,76 @@
+// Copyright 2020 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/////////////////////////////////////////////////////////////////
+// FFI wrapper for Crux-mir static simulator tool
+/////////////////////////////////////////////////////////////////
+
+use std::default::Default;
+
+// Create an abstract value of type <T>
+//
+// This should only be used on types that occupy contiguous memory
+// and where all possible bit-patterns are legal.
+// e.g., u8/i8, ... u128/i128, f32/f64
+pub fn abstract_value<T: Default>() -> T {
+    T::default()
+}
+
+// Add an assumption
+pub fn assume(_cond: bool) {
+    // TODO: ??
+}
+
+// Reject the current execution with a verification failure.
+//
+// In almost all circumstances, report_error should
+// be used instead because it generates an error message.
+pub fn abort() {
+    assert!(false)
+}
+
+// Reject the current execution path with a verification success.
+// This is equivalent to assume(false)
+// and the opposite of report_error.
+//
+// Typical usage is in generating symbolic values when the value
+// does not meet some criteria.
+pub fn reject() -> ! {
+    // TODO: ???
+    panic!("reject")
+}
+
+// Detect whether the program is being run symbolically in KLEE
+// or being replayed using the kleeRuntest runtime.
+//
+// This is used to decide whether to display the values of
+// variables that may be either symbolic or concrete.
+pub fn is_replay() -> bool {
+    false
+}
+
+// Reject the current execution with a verification failure
+// and an error message.
+pub fn report_error(message: &str) {
+    // Mimic the format of klee_report_error
+    // (We don't use klee_report_error because it is not
+    // supported by the kleeRuntest library.)
+    eprintln!("KLEE: ERROR:{}", message);
+    abort();
+}
+
+// Check an assertion
+pub fn verify(cond: bool) {
+    if !cond {
+        report_error("verification failed");
+    }
+}
+
+/////////////////////////////////////////////////////////////////
+// End
+/////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Initial support for crux-mir.

This will break things with cargo-verify. In particular, when running cargo in compatibility-test you must specify the verifier like this: cargo test --features "verify propverify/verifier-crux"