### PR TITLE
Add crux to verification-annotations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 - [Installation](installation.md)
   - [Rust](install-rust.md)
   - [KLEE](install-klee.md)
+  - [crux](install-crux.md)
 
 - Usage
 

--- a/docs/install-crux.md
+++ b/docs/install-crux.md
@@ -1,0 +1,94 @@
+# Installation
+
+The best way to install crux (aka mir-verifier) is to follow the instructions on
+[crux's GitHub page](https://github.com/GaloisInc/mir-verifier).
+
+For convenience, instructions for installing crux and its dependencies are
+provided below.
+
+
+We are going to install Haskell, Rust, mir-json, Yices and crux.
+
+Where possible `apt` is used. 
+Everything else is installed under `$HOME`.
+
+
+### Installing Haskell
+
+``` shell
+sudo apt install cabal-install ghc
+cabal new-update
+```
+
+Make sure `PATH` includes `$HOME/.cabal/bin`.
+
+
+### Installing Rust
+
+Install rust using rustup.
+mir-json requires nightly-2020-03-22 so we will get that.
+
+``` shell
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+rustup toolchain install nightly-2020-03-22 --force
+rustup default nightly-2020-03-22
+rustup component add --toolchain nightly-2020-03-22 rustc-dev
+```
+
+Make sure `PATH` includes `$HOME/.cargo/bin`.
+
+### Install mir-json
+
+``` shell
+git clone git@github.com:GaloisInc/mir-json.git
+cd mir-json
+RUSTC_WRAPPER=./rustc-rpath.sh cargo install --locked
+```
+
+### Install Yices
+
+``` shell
+git clone git@github.com:SRI-CSL/yices2.git
+cd yices2
+autoconf
+./configure --prefix="$HOME/.local"
+make
+make install
+```
+
+Make sure `PATH` includes `$HOME/.local/bin`
+
+### Building Crux
+
+``` shell
+git clone git@github.com:GaloisInc/mir-verifier.git
+cd mir-verifier
+git submodule update --init
+cabal v2-build
+./translate_libs.sh
+cabal v2-install crux-mir
+```
+
+### Shell init script
+
+Add the following lines to your shell init script (assuming crux was cloned into
+`$HOME/mir-verifier`).
+
+``` shell
+export PATH=$HOME/.local/bin:$HOME/.cabal/bin:$HOME/.cargo/bin:$PATH
+export CRUX_RUST_LIBRARY_PATH=$HOME/mir-verifier/rlibs
+```
+### Testing
+
+Run crux's test suite:
+
+``` shell
+cd mir-verifier
+cabal v2-test
+# [...]
+# All 254 tests passed (322.16s)
+# Test suite test: PASS
+# Test suite logged to:
+# [...]
+# 1 of 1 test suites (1 of 1 test cases) passed.
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,5 +9,5 @@ have some errors and omissions (corrections welcome!)
 Follow the following steps in order
 
 - [Installing the Rust compiler](install-rust.md)
-- [Installing KLEE's and its dependencies](install-klee.md)
-
+- [Installing KLEE and its dependencies](install-klee.md)
+- [Installing crux and its dependencies](install-crux.md)

--- a/verification-annotations/Cargo.toml
+++ b/verification-annotations/Cargo.toml
@@ -8,11 +8,11 @@ authors = [
 edition = "2018"
 description = "verification annotation library"
 categories = ["development-tools::testing"]
-keywords = ["klee", "mir", "verification", "testing"]
+keywords = ["klee", "crux", "mir", "verification", "testing"]
 license = "MIT OR Apache-2.0"
 
 [features]
-
+verifier-crux = []
 verifier-klee = []
 
 [dependencies]

--- a/verification-annotations/src/crux.rs
+++ b/verification-annotations/src/crux.rs
@@ -1,0 +1,103 @@
+// Copyright 2020 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/////////////////////////////////////////////////////////////////
+// FFI wrapper for Crux-mir static simulator tool
+/////////////////////////////////////////////////////////////////
+
+// This module should be use with crux (e.g. 'cargo crux-test')
+#[cfg(not(crux))]
+compiler_error!("Expected 'crux'");
+
+extern crate crucible;
+
+// Create an abstract value of type <T>
+//
+// This should only be used on types that occupy contiguous memory
+// and where all possible bit-patterns are legal.
+// e.g., u8/i8, ... u128/i128, f32/f64
+pub fn abstract_value<T: crucible::Symbolic>() -> T {
+    // We assume the string argument is just for reporting to the user, and
+    // doesn't affect the results.
+    T::symbolic("")
+}
+
+// Add an assumption
+pub fn assume(cond: bool) {
+    crucible::crucible_assume!(cond)
+}
+
+// Reject the current execution with a verification failure.
+//
+// In almost all circumstances, report_error should
+// be used instead because it generates an error message.
+pub fn abort() {
+    crucible::crucible_assert!(false)
+}
+
+// Reject the current execution path with a verification success.
+// This is equivalent to assume(false)
+// and the opposite of report_error.
+//
+// Typical usage is in generating symbolic values when the value
+// does not meet some criteria.
+pub fn reject() -> ! {
+    crucible::crucible_assume!(false);
+    panic!("should have been rejected!");
+}
+
+pub fn is_replay() -> bool {
+    panic!("crux doesn't support replay")
+}
+
+// Reject the current execution with a verification failure
+// and an error message.
+pub fn report_error(message: &str) {
+    crucible::crucible_assert!(false, "VERIFIER: ERROR: {}", message);
+}
+
+// Check an assertion
+pub fn verify(cond: bool) {
+    crucible::crucible_assert!(cond, "VERIFIER: verification failed");
+}
+
+pub fn expect_raw(msg: &str) {
+    panic!("not implemented")
+}
+
+// Declare that failure is the expected behaviour
+pub fn expect(msg: Option<&str>) {
+    panic!("not implemented")
+}
+
+
+// TODO: call crucible_assert! to preserve line number info.
+#[macro_export]
+macro_rules! assert {
+    ($cond:expr) => { $crate::verify($cond) };
+    // ($cond:expr,) => { ... };
+    // ($cond:expr, $($arg:tt)+) => { ... };
+}
+
+#[macro_export]
+macro_rules! assert_eq {
+    ($left:expr, $right:expr) => { $crate::verify($left == $right) };
+    // ($left:expr, $right:expr,) => { ... };
+    // ($left:expr, $right:expr, $($arg:tt)+) => { ... };
+}
+
+#[macro_export]
+macro_rules! assert_ne {
+    ($left:expr, $right:expr) => { $crate::verify($left != $right) };
+    // ($left:expr, $right:expr,) => { ... };
+    // ($left:expr, $right:expr, $($arg:tt)+) => { ... };
+}
+
+/////////////////////////////////////////////////////////////////
+// End
+/////////////////////////////////////////////////////////////////

--- a/verification-annotations/src/lib.rs
+++ b/verification-annotations/src/lib.rs
@@ -11,6 +11,11 @@ mod klee;
 #[cfg(feature = "verifier-klee")]
 pub use crate::klee::*;
 
+#[cfg(feature = "verifier-crux")]
+mod crux;
+#[cfg(feature = "verifier-crux")]
+pub use crate::crux::*;
+
 // At the moment, the cargo-verify script does not support
 // use of a separate test directory so, for now, we put
 // the tests here.

--- a/verification-annotations/src/tests.rs
+++ b/verification-annotations/src/tests.rs
@@ -5,20 +5,33 @@
 #[cfg(feature = "verifier-klee")]
 use crate::klee as verifier;
 
-#[test]
+#[cfg(feature = "verifier-crux")]
+use crate::crux as verifier;
+#[cfg(feature = "verifier-crux")]
+use crate::assert;
+#[cfg(feature = "verifier-crux")]
+use crate::assert_eq;
+#[cfg(feature = "verifier-crux")]
+use crate::assert_ne;
+
+
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
 fn t0() {
     let a = crate::abstract_value::<u32>();
     let b = verifier::abstract_value::<u32>();
     verifier::assume(4 <= a && a <= 7);
     verifier::assume(5 <= b && b <= 8);
+
+    #[cfg(not(feature = "verifier-crux"))]
     if verifier::is_replay() { eprintln!("Test values: a = {}, b = {}", a, b) }
 
     let r = a*b;
     assert!(20 <= r && r <= 56);
 }
 
-#[cfg(test)]
-#[test]
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
 fn t1() {
     let a = verifier::abstract_value::<u32>();
     let b = verifier::abstract_value::<u32>();
@@ -28,11 +41,12 @@ fn t1() {
     assert!(20 <= r && r <= 56);
 }
 
-
-#[cfg(test)]
-#[test]
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
 fn t2() {
+    #[cfg(not(feature = "verifier-crux"))]
     verifier::expect(Some("multiply with overflow"));
+
     let a = verifier::abstract_value::<u32>();
     let b = verifier::abstract_value::<u32>();
     let r = a*b;
@@ -41,10 +55,12 @@ fn t2() {
     assert!(20 <= r && r <= 56);
 }
 
-#[cfg(test)]
-#[test]
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
 fn t3() {
+    #[cfg(not(feature = "verifier-crux"))]
     verifier::expect(Some("assertion failed"));
+
     let a = verifier::abstract_value::<u32>();
     let b = verifier::abstract_value::<u32>();
     verifier::assume(4 <= a && a <= 7);
@@ -53,10 +69,12 @@ fn t3() {
     assert!(20 <= r && r < 56);
 }
 
-#[cfg(test)]
-#[test]
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
 fn t4() {
+    #[cfg(not(feature = "verifier-crux"))]
     verifier::expect(None);
+
     let a = verifier::abstract_value::<u32>();
     let b = verifier::abstract_value::<u32>();
     verifier::assume(4 <= a && a <= 7);


### PR DESCRIPTION
For example (after following the instructions in install-crux.md):

```shell
cd verification-annotations
RUSTFLAGS='--cfg test' cargo crux-test --features 'verifier-crux'
```

`assert!` reports the line number of `crux::verify` (so always the same line)!
