### PR TITLE
Add crux to propverify

### DIFF
--- a/compatibility-test/Cargo.toml
+++ b/compatibility-test/Cargo.toml
@@ -18,3 +18,4 @@ proptest = { version = "*" }
 
 [features]
 verifier-klee = ["propverify/verifier-klee"]
+verifier-crux = ["propverify/verifier-crux"]

--- a/propverify/Cargo.toml
+++ b/propverify/Cargo.toml
@@ -13,10 +13,12 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [features]
+# Enable support for symbolic f32 and f64
+float = []
 
-default = ["verifier-klee"]
+verifier-klee = [ "verification-annotations/verifier-klee", "float" ]
+verifier-crux = [ "verification-annotations/verifier-crux" ]
 
-verifier-klee = [ "verification-annotations/verifier-klee" ]
 
 [dependencies]
 verification-annotations = { path = "../verification-annotations" }

--- a/propverify/src/lib.rs
+++ b/propverify/src/lib.rs
@@ -45,7 +45,7 @@ pub mod prelude {
         pub mod num {
             pub use crate::strategy::{i128, i16, i32, i64, i8, isize};
             pub use crate::strategy::{u128, u16, u32, u64, u8, usize};
-            pub use crate::strategy::{f32, f64};
+            #[cfg(feature = "float")] pub use crate::strategy::{f32, f64};
         }
     }
 


### PR DESCRIPTION
For example:

```shell
cd compatibility-test
RUSTFLAGS='--cfg test --cfg verify' cargo crux-test --features 'verifier-crux' -- -t1
```

Some of the test fail (for the wrong reason), crux is pointing at strategy.rs:144:28, which is this call `Box::new(self)` in `Strategy::boxed`, with the message "unimplemented cast: Unsize".  In other case crux is pointing at ./lib/libcore/mem/maybe_uninit.rs:788:9 (crux's implementation of safe core) with the message "unimplemented cast: Misc".
