### PR TITLE
Add assert macros to Klee

### DIFF
--- a/verification-annotations/src/klee.rs
+++ b/verification-annotations/src/klee.rs
@@ -100,6 +100,33 @@ pub fn expect(msg: Option<&str>) {
     }
 }
 
+
+#[macro_export]
+macro_rules! assert {
+    ($cond:expr) => {
+        if ! $cond {
+            eprintln!("VERIFIER: assertion failed: {}", stringify!($cond));
+            abort();
+        }
+    };
+    // ($cond:expr,) => { ... };
+    // ($cond:expr, $($arg:tt)+) => { ... };
+}
+
+#[macro_export]
+macro_rules! assert_eq {
+    ($left:expr, $right:expr) => { $crate::assert!(($left) == ($right)); };
+    // ($left:expr, $right:expr,) => { ... };
+    // ($left:expr, $right:expr, $($arg:tt)+) => { ... };
+}
+
+#[macro_export]
+macro_rules! assert_ne {
+    ($left:expr, $right:expr) => { $crate::assert!(($left) != ($right)); };
+    // ($left:expr, $right:expr,) => { ... };
+    // ($left:expr, $right:expr, $($arg:tt)+) => { ... };
+}
+
 /////////////////////////////////////////////////////////////////
 // End
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I implemented assert using eprintln and abort, with the same message string as I did for crux, assuming line number info will be added by Klee(?). Should I change that to just forward cond to std::assert?