### PR TITLE
Docker: seahorn support

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -17,5 +17,6 @@ set -e
 (cd docker/minisat && ../mkimage rvt_minisat    Dockerfile)
 (cd docker/stp     && ../mkimage rvt_stp        Dockerfile)
 (cd docker/klee    && ../mkimage rvt_klee       Dockerfile)
-
-docker/mkimage rvt docker/rvt_Dockerfile
+(cd docker/z3      && ../mkimage rvt_z3         Dockerfile)
+(cd docker/seahorn && ../mkimage rvt_seahorn    Dockerfile)
+(cd docker/rvt     && ../mkimage rvt            Dockerfile)

--- a/docker/rvt/Dockerfile
+++ b/docker/rvt/Dockerfile
@@ -1,4 +1,4 @@
-FROM rvt_klee:latest
+FROM rvt_seahorn:latest
 
 # Placeholder args that are expected to be passed in at image build time.
 # See https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
@@ -6,17 +6,14 @@ ARG USERNAME=user-name-goes-here
 ARG USER_UID=1000
 ARG USER_GID=${USER_UID}
 
-# Directory we copy RVT repo into
+# Directory we mount RVT repo in
 ENV RVT_DIR=/home/rust-verification-tools
-
-# Copy the rust-verification-tools repo into this image.
-# (An alternative would be to mount the directory when running the image.)
-USER root
 
 # The following replicates code in base_Dockerfile and
 # can be deleted next time I do a full rebuild of the images
-RUN echo '${USERNAME}  ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+USER root
 RUN apt install sudo
+RUN echo '${USERNAME}  ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 
 # Switch to USERNAME and install tools / set environment
 USER ${USERNAME}

--- a/docker/seahorn/Dockerfile
+++ b/docker/seahorn/Dockerfile
@@ -1,0 +1,66 @@
+FROM rvt_z3:latest
+
+USER root
+
+RUN echo ${Z3_DIR} && ls ${Z3_DIR}
+
+# Install Debian and Python dependencies
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get --yes update \
+  && apt-get install --no-install-recommends --yes \
+  build-essential \
+  clang-10 \
+  clang-format-10 \
+  clang-tools-10 \
+  cmake \
+  g++-7-multilib \
+  gcc-multilib \
+  git \
+  lib32stdc++-7-dev \
+  libboost-all-dev \
+  libgmp-dev \
+  libgmpxx4ldbl \
+  libncurses5-dev \
+  lld-10 \
+  llvm-10 \
+  ncurses-doc \
+  ninja-build \
+  subversion \
+  # Cleanup
+  && apt-get clean
+
+WORKDIR /opt
+
+ARG YICES_VERSION=2.6.2
+RUN curl --location https://yices.csl.sri.com/releases/${YICES_VERSION}/yices-${YICES_VERSION}-x86_64-pc-linux-gnu-static-gmp.tar.gz > yices.tgz \
+  && tar xf yices.tgz \
+  && rm yices.tgz
+
+RUN mkdir /root/seahorn
+WORKDIR /root/seahorn
+
+RUN git clone https://github.com/yvizel/verify-c-common.git
+RUN git clone --branch=dev10 https://github.com/seahorn/seahorn.git
+
+RUN mkdir seahorn/build \
+  && cd seahorn/build \
+  && cmake \
+     -DCMAKE_INSTALL_PREFIX=run \
+     # -DCMAKE_BUILD_TYPE="Debug" \
+     -DCMAKE_BUILD_TYPE="Release" \
+     -DCMAKE_CXX_COMPILER="clang++-10" \
+     -DCMAKE_C_COMPILER="clang-10" \
+     -DZ3_ROOT=${Z3_DIR} \
+     -DYICES2_HOME=${YICES_DIR} \
+     -DSEA_ENABLE_LLD="ON" \
+     -GNinja \
+     -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+     -DLLVM_DIR=${RUSTC_DIR}/build/x86_64-unknown-linux-gnu/llvm/lib/cmake/llvm \
+     ..
+
+RUN cd seahorn/build && cmake --build . --target extra  && cmake ..
+RUN cd seahorn/build && cmake --build . --target crab  && cmake ..
+RUN cd seahorn/build && cmake --build . --target install
+# RUN cd seahorn/build && cmake --build . --target units_z3
+# RUN cd seahorn/build && cmake --build . --target units_yices2
+# RUN cd seahorn/build && cmake --build . --target package

--- a/docker/z3/Dockerfile
+++ b/docker/z3/Dockerfile
@@ -1,0 +1,16 @@
+FROM rvt_klee:latest
+
+USER root
+RUN mkdir /home/z3
+WORKDIR /home/z3
+
+# Install the binary version of Z3.
+# (Changing this to build from source would be fine - but slow)
+#
+# The Ubuntu version is a little out of date but that doesn't seem to cause any problems
+ARG Z3_VERSION=4.8.7
+RUN curl --location https://github.com/Z3Prover/z3/releases/download/z3-${Z3_VERSION}/z3-${Z3_VERSION}-x64-ubuntu-16.04.zip > z3.zip \
+  && unzip -q z3.zip \
+  && rm z3.zip
+
+ENV Z3_DIR=/home/z3/z3-${Z3_VERSION}-x64-ubuntu-16.04


### PR DESCRIPTION
These dockerfiles build SeaHorn and its dependencies.

Currently untested - all I know is that installation does not fail.