### PR TITLE
Demos directory: a home for code used in documentation examples

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,9 @@
+# Demo code
+
+This directory contains demonstration code.
+
+- `demos/simple/klee`: using KLEE directly to verify Rust code.
+  See [docs/using-klee](../docs/using-klee.md) for description. 
+- `demos/simple/annotations`: using the `verification-annotations` crate with
+  `cargo-verify`.
+  See [docs/using-annotations](../docs/using-annotations.md) for description. 

--- a/demos/simple/annotations/Cargo.toml
+++ b/demos/simple/annotations/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "try-verifier"
+version = "0.1.0"
+authors = ["adreid"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+verification-annotations = { path="/home/rust-verification-tools/verification-annotations" }
+
+[features]
+verifier-klee = ["verification-annotations/verifier-klee"]
+verifier-crux = ["verification-annotations/verifier-crux"]

--- a/demos/simple/annotations/src/main.rs
+++ b/demos/simple/annotations/src/main.rs
@@ -1,0 +1,15 @@
+use verification_annotations as verifier;
+
+#[cfg_attr(feature="verifier-crux", crux_test)]
+#[cfg_attr(not(feature="verifier-crux"), test)]
+fn t1() {
+    let a : u32 = verifier::AbstractValue::abstract_value();
+    let b : u32 = verifier::AbstractValue::abstract_value();
+    verifier::assume(1 <= a && a <= 1000);
+    verifier::assume(1 <= b && b <= 1000);
+    if verifier::is_replay() {
+        eprintln!("Test values: a = {}, b = {}", a, b);
+    }
+    let r = a*b;
+    verifier::assert!(1 <= r && r < 1000000);
+}

--- a/demos/simple/annotations/verify.sh
+++ b/demos/simple/annotations/verify.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+cargo clean
+
+# verify using KLEE
+# this should detect an error
+( cargo-verify . --tests --verbose > out1 || true )
+cat out1
+grep -q "test t1 ... .*ERROR" out1
+
+# replay input values
+( cargo-verify . --tests --replay > out2 || true )
+cat out2
+grep -q "Test values: a = 1000, b = 1000" out2

--- a/demos/simple/klee/Cargo.toml
+++ b/demos/simple/klee/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "try-klee"
+version = "0.1.0"
+authors = [""]
+edition = "2018"
+
+[dependencies]
+verification-annotations = { path="/home/rust-verification-tools/verification-annotations" }
+
+[features]
+verifier-klee = ["verification-annotations/verifier-klee"]

--- a/demos/simple/klee/src/main.rs
+++ b/demos/simple/klee/src/main.rs
@@ -1,0 +1,13 @@
+use verification_annotations as verifier;
+
+fn main() {
+    let a : u32 = verifier::AbstractValue::abstract_value();
+    let b : u32 = verifier::AbstractValue::abstract_value();
+    verifier::assume(1 <= a && a <= 1000);
+    verifier::assume(1 <= b && b <= 1000);
+    if verifier::is_replay() {
+        eprintln!("Test values: a = {}, b = {}", a, b);
+    }
+    let r = a*b;
+    verifier::assert!(1 <= r && r <= 1000000);
+}

--- a/demos/simple/klee/verify.sh
+++ b/demos/simple/klee/verify.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+export RUSTFLAGS="-Clto -Cembed-bitcode=yes --emit=llvm-bc $RUSTFLAGS"
+export RUSTFLAGS="--cfg=verify $RUSTFLAGS"
+export RUSTFLAGS="-Warithmetic-overflow -Coverflow-checks=yes $RUSTFLAGS"
+export RUSTFLAGS="--cfg=verify $RUSTFLAGS"
+export RUSTFLAGS="-Warithmetic-overflow -Coverflow-checks=yes $RUSTFLAGS"
+export RUSTFLAGS="-Zpanic_abort_tests -Cpanic=abort $RUSTFLAGS"
+
+# optional for this simple example
+export RUSTFLAGS="-Copt-level=1 $RUSTFLAGS"
+export RUSTFLAGS="-Cno-vectorize-loops -Cno-vectorize-slp $RUSTFLAGS"
+export RUSTFLAGS="-Ctarget-feature=-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2 $RUSTFLAGS"
+
+cargo clean
+cargo build --features=verifier-klee
+
+# verify using KLEE
+rm -rf kleeout
+klee --libc=klee --silent-klee-assume --output-dir=kleeout --warnings-only-to-file target/debug/deps/try_klee*.bc
+
+# view input value for first path
+ktest-tool kleeout/test000001.ktest
+
+# replay input values
+KTEST_FILE=kleeout/test000001.ktest cargo run --features=verifier-klee

--- a/docs/using-annotations.md
+++ b/docs/using-annotations.md
@@ -139,6 +139,8 @@ the same simple example we
 This might be useful if you wonder how propverify is implemented
 or if you prefer to use the more conventional verifier interface.
 
+This code is in `demos/simple/klee` and the shell commands in this
+file are in `demos/simple/klee/verify.sh`.
 
 ```
 use verification_annotations as verifier;
@@ -175,13 +177,12 @@ to invoke KLEE.
 (We cannot run this example with a fuzzer.)
 
 
-## Creating a test crate
-
 The Rust compiler and KLEE are in the Dockerfile (see
 [installation](installation.md)) so start the Docker image
 by running
 
 ``` shell
+cd demos/simple/annotations
 ../docker/run
 ```
 
@@ -194,37 +195,6 @@ a separate editor to edit the files in another terminal.)
 To try the above example, we will create a crate in which to experiment with this
 code.
 
-```
-cargo new try-verifier
-cd try-verifier
-
-cat >> Cargo.toml  << "EOF"
-
-verification-annotations = { path="/home/rust-verification-tools/verification-annotations" }
-
-[features]
-verifier-klee = ["verification-annotations/verifier-klee"]
-verifier-crux = ["verification-annotations/verifier-crux"]
-EOF
-
-cat > src/main.rs  << "EOF"
-use verification_annotations as verifier;
-
-#[cfg_attr(feature="verifier-crux", crux_test)]
-#[cfg_attr(not(feature="verifier-crux"), test)]
-fn t1() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
-    verifier::assume(1 <= a && a <= 1000);
-    verifier::assume(1 <= b && b <= 1000);
-    if verifier::is_replay() {
-        eprintln!("Test values: a = {}, b = {}", a, b);
-    }
-    let r = a*b;
-    verifier::assert!(1 <= r && r < 1000000);
-}
-EOF
-```
 
 ## Verifying with KLEE (and `cargo-verify`)
 

--- a/scripts/regression-test
+++ b/scripts/regression-test
@@ -3,6 +3,8 @@
 set -e
 
 readonly FLAGS="--backend=klee --verbose --clean"
+(cd demos/simple/annotations; ./verify.sh)
+(cd demos/simple/klee; ./verify.sh)
 cargo-verify ${FLAGS} --tests verification-annotations
 cargo-verify ${FLAGS} --tests compatibility-test
 


### PR DESCRIPTION
Rearranging demo code into a demos directory.
Apart from the demos/simple/*/verify.sh scripts and the addition to scripts/regression-test, there is no new content.
This is just cleaning things up in preparation for the next PR

A useful/important side effect of putting this code in the repo is that we can include them in regression-tests.