### PR TITLE
Docker: build more code as USERNAME instead of root

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get --yes update \
   ninja-build \
   perl \
   pkg-config \
+  python \
   python3 \
   python3-minimal \
   python3-pip \

--- a/docker/klee/Dockerfile
+++ b/docker/klee/Dockerfile
@@ -1,8 +1,8 @@
 FROM rvt_stp:latest
 
-USER root
-
+# Temporary patch until we update base
 # Install python2 - because uclibc needs it
+USER root
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get --yes update \
   && apt-get install --no-install-recommends --yes \
@@ -10,14 +10,19 @@ RUN apt-get --yes update \
   # Cleanup
   && apt-get clean
 
-USER root
-RUN mkdir /home/klee
-WORKDIR /home/klee
+ARG USERNAME
+
+WORKDIR ${USER_HOME}
+COPY build_googletest .
+COPY build_klee .
+RUN chown ${USERNAME} -R build_googletest build_klee
+
+USER ${USERNAME}
+WORKDIR ${USER_HOME}
 
 ARG GTEST_VERSION
-COPY build_googletest .
+ENV GTEST_DIR=${USER_HOME}/googletest-release-${GTEST_VERSION}
 RUN sh build_googletest
 
 ARG KLEE_VERSION
-COPY build_klee .
 RUN sh build_klee

--- a/docker/klee/build_klee
+++ b/docker/klee/build_klee
@@ -29,8 +29,8 @@ cmake \
   -DLLVMCXX="${LLVMCXX}" \
   -DLLVM_CONFIG_BINARY="${LLVM_CONFIG}" \
   -DENABLE_UNIT_TESTS=ON \
-  -DGTEST_SRC_DIR=/home/klee/googletest-release-${GTEST_VERSION} \
+  -DGTEST_SRC_DIR=${GTEST_DIR} \
   ..
 make -j 4
 make check
-make install
+sudo make install

--- a/docker/rustc/Dockerfile
+++ b/docker/rustc/Dockerfile
@@ -1,5 +1,7 @@
 FROM rvt_base:latest
 
+ARG USERNAME
+
 USER ${USERNAME}
 WORKDIR ${USER_HOME}
 


### PR DESCRIPTION
This PR consists of

- a bugfix that builds rustc as USERNAME instead of root
  (We thought this was already being done - but had forgotten to write 'ARG USERNAME')

- a change of how we build KLEE so that it is built as USERNAME instead of root