### PR TITLE
Use structopt instead of using clap directly

### DIFF
--- a/rvt-patch-llvm/Cargo.toml
+++ b/rvt-patch-llvm/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2.33"
 log  = "0.4"
 stderrlog = "0.5"
+structopt = "0.3"
 regex = "0.2"
 # inkwell = { git = "https://github.com/TheDan64/inkwell", branch = "master", features = ["llvm10-0"] }
 # inkwell = { features = ["llvm10-0"] }


### PR DESCRIPTION
structopt can catch arg-parsing bugs at compile time.
structopt uses clap in the background.
