### PR TITLE
PropVerify: minor improvements

### DIFF
--- a/demos/simple/ffi/src/main.rs
+++ b/demos/simple/ffi/src/main.rs
@@ -15,14 +15,14 @@ fn bar(x: i32) -> i32 {
 }
 
 proptest!{
-    fn main(i in any::<i32>()) {
+    fn main(i: i32) {
         prop_assert!(bar(i) != i)
     }
 }
 
 proptest! {
     #[test]
-    fn inequal(x in any::<i32>()) {
+    fn inequal(x: i32) {
         prop_assert!(bar(x) != x)
     }
 }
@@ -30,7 +30,7 @@ proptest! {
 proptest! {
     #[test]
     #[should_panic(expected = "assertion failed")]
-    fn greater(x in any::<i32>()) {
+    fn greater(x: i32) {
         prop_assert!(bar(x) > x)
     }
 }

--- a/docs/using-ffi.md
+++ b/docs/using-ffi.md
@@ -49,14 +49,14 @@ fn bar(x: i32) -> i32 {
 }
 
 proptest!{
-    fn main(i in any::<i32>()) {
+    fn main(i: i32) {
         prop_assert!(bar(i) != i)
     }
 }
 
 proptest! {
     #[test]
-    fn inequal(x in any::<i32>()) {
+    fn inequal(x: i32) {
         prop_assert!(bar(x) != x)
     }
 }
@@ -64,7 +64,7 @@ proptest! {
 proptest! {
     #[test]
     #[should_panic(expected = "assertion failed")]
-    fn greater(x in any::<i32>()) {
+    fn greater(x: i32) {
         prop_assert!(bar(x) > x)
     }
 }

--- a/propverify/src/strategy.rs
+++ b/propverify/src/strategy.rs
@@ -192,7 +192,16 @@ macro_rules! proptest {
 
           $body
       }
-  };
+    };
+    (
+      $(#[$meta:meta])*
+      fn $test_name:ident($($parm:ident : $s:ty),+ $(,)?) $body:block
+    ) => {
+        $crate::proptest!{
+            $(#[$meta])*
+            fn $test_name($($parm in $crate::prelude::any::<$s>()),+) $body
+        }
+    };
 }
 
 /// Assume that condition `cond` is true

--- a/propverify/src/strategy.rs
+++ b/propverify/src/strategy.rs
@@ -822,8 +822,6 @@ pub struct VecStrategy<S: Strategy> {
     size: usize, // concrete size to be more friendly to concolic/DSE
 }
 impl<S: Strategy> Strategy for VecStrategy<S>
-where
-    S: Strategy + Clone,
 {
     type Value = Vec<S::Value>;
     fn value(&self) -> Self::Value {


### PR DESCRIPTION
Adds support for strategies of the form "x: i32" (which invokes Arbitrary).

Also modifies trait bounds to match proptest better.