### PR TITLE
Script: fix --replay problem

### DIFF
--- a/scripts/cargo-verify
+++ b/scripts/cargo-verify
@@ -197,7 +197,8 @@ def compile(label, crate, runtests, verbose, rustflags, features, target):
   # (This may not be inside the crate if using workspaces)
   targetdir = metadata["target_directory"]
 
-  flags = features
+  flags = []
+  flags.extend(features)
   if verbose: flags.append("-v")
   if runtests: flags.append("--tests")
 


### PR DESCRIPTION
--replay was not working with build.rs-enabled code because
of a Python gotcha where 'copying' a list only copies a pointer to the list
so modifying the 'copy' modifies the original.

The fix is to really copy the list so that the 'features' list does not get
modified by accident.