### PR TITLE
Support for symbolic strings

### DIFF
--- a/demos/bottlenecks/regex/Cargo.toml
+++ b/demos/bottlenecks/regex/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "regex"
+version = "0.1.0"
+authors = ["Alastair Reid <adreid@google.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+verification-annotations = { path="/home/rust-verification-tools/verification-annotations" }
+regex = "1.4"
+
+[features]
+verifier-klee = ["verification-annotations/verifier-klee"]
+verifier-crux = ["verification-annotations/verifier-crux"]
+verifier-seahorn = ["verification-annotations/verifier-seahorn"]

--- a/demos/bottlenecks/regex/src/main.rs
+++ b/demos/bottlenecks/regex/src/main.rs
@@ -1,0 +1,59 @@
+/// Test the use of regular expressions
+///
+/// This test checks three things
+///
+/// 1. Feature support for hand-vectorized code that
+///    includes a "slow path" if vector instructions are not
+///    available.
+///    (We are testing that the "fast path" is ignored.)
+///
+/// 2. Feature support for an aligned memory allocator.
+///    (This is the part of the hand-vectorized code that we
+///    cannot disable.)
+///
+/// 3. A path explosion in the handling of regular expressions.
+///    At present, this explosion is not fixed and we keep the
+///    strings very short to keep execution time reasonable.
+
+use regex::Regex;
+use verification_annotations as verifier;
+
+fn main() {
+    println!("Hello, world!");
+}
+
+const N: usize = 2;
+
+/// Test use of regular expressions
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
+fn regex_ok() {
+    let a = verifier::verifier_nondet_ascii_string(N);
+
+    if verifier::is_replay() {
+        println!("Value a = {:?}", a);
+    }
+
+    verifier::assume(Regex::new(r"[0-1]{2}").unwrap().is_match(&a));
+
+    let i: u32 = a.parse().unwrap();
+    verifier::assert!(i <= 11);
+}
+
+
+/// Test use of regular expressions
+#[cfg_attr(not(feature = "verifier-crux"), test)]
+#[cfg_attr(feature = "verifier-crux", crux_test)]
+fn regex_should_fail() {
+    verifier::expect(Some("assertion failed"));
+    let a = verifier::verifier_nondet_ascii_string(N);
+
+    if verifier::is_replay() {
+        println!("Value a = {:?}", a);
+    }
+
+    verifier::assume(Regex::new(r"[0-1]{2}").unwrap().is_match(&a));
+
+    let i: u32 = a.parse().unwrap();
+    verifier::assert!(i < 11);
+}

--- a/scripts/regression-test
+++ b/scripts/regression-test
@@ -11,5 +11,6 @@ cargo-verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/bornholt2018-1/C
 cargo-verify ${FLAGS} --tests --manifest-path=demos/simple/ffi/Cargo.toml
 cargo-verify ${FLAGS} -v -v -v --manifest-path=demos/simple/argv/Cargo.toml -- foo foo
 cargo verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/merging/Cargo.toml --backend-flags=--use-merge
+cargo verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/regex/Cargo.toml
 
 echo Regression test successful

--- a/verification-annotations/src/lib.rs
+++ b/verification-annotations/src/lib.rs
@@ -6,6 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![feature(cstring_from_vec_with_nul)]
+
 // Traits for creating symbolic/abstract values
 mod traits;
 pub use crate::traits::*;


### PR DESCRIPTION
Composed of

- Efficient support for creating symbolic Vec<u8>.
- Tests involving strings
- Creating a new top-level directory 'runtime' to contain C support code required to interface between what the Rust library expects from the C library and the set of operations provided by different verifiers.
  - This will probably end up being a combination of code that is needed by all verifiers and code that is only needed with a subset of the verifier backends that we support. So it will end up requiring conditional compilation.
  - For now all it contains is support for allocating aligned memory blocks (used by crates like Regex).
  - In the near future, I will add code to support code that uses pthreads but only requires one thread. (i.e., to support almost every thread-safe library)
- Tests involving the standard Regex crate