### PR TITLE
kcachegrind support

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -16,6 +16,11 @@ cargo clean --manifest-path cargo-verify/Cargo.toml
 rm -rf docker/rvt/cargo-verify
 cp -a `pwd`/cargo-verify docker/rvt/cargo-verify
 
+# Copy rust2calltree over
+cargo clean --manifest-path rust2calltree/Cargo.toml
+rm -rf docker/rust2calltree/rust2calltree
+cp -a `pwd`/rust2calltree docker/rust2calltree/rust2calltree
+
 # Build each image
 #
 # Note that each image is built in a subdirectory to avoid breaking
@@ -35,3 +40,4 @@ cp -a `pwd`/cargo-verify docker/rvt/cargo-verify
 (cd docker/yices   && ../mkimage rvt_yices      Dockerfile)
 (cd docker/seahorn && ../mkimage rvt_seahorn    Dockerfile)
 (cd docker/rvt     && ../mkimage rvt            Dockerfile)
+(cd docker/rust2calltree && ../mkimage rvt_r2ct Dockerfile)

--- a/docker/init
+++ b/docker/init
@@ -8,5 +8,6 @@ make -C runtime TGT=seahorn
 
 # Build tools
 mkdir -p ${USER_HOME}/bin
+cargo install --root=${USER_HOME} --path=${RVT_DIR}/rust2calltree
 cargo install --root=${USER_HOME} --path=${RVT_DIR}/rvt-patch-llvm
 cargo +nightly install --root=${USER_HOME} --path=${RVT_DIR}/cargo-verify

--- a/docker/run
+++ b/docker/run
@@ -6,4 +6,7 @@ readonly RVT_DST=/home/rust-verification-tools
 readonly MOUNT_PWD="type=bind,source=${PWD},target=${PWD}"
 readonly MOUNT_RVT="type=bind,source=${RVT_SRC},target=${RVT_DST}"
 
-sudo docker run --rm --mount ${MOUNT_RVT} --mount ${MOUNT_PWD} --workdir ${PWD} -it rvt:latest $*
+# based on https://dzone.com/articles/docker-x11-client-via-ssh
+readonly X11="--net=host --env=DISPLAY --volume=$HOME/.Xauthority:/home/$USER/.Xauthority:rw"
+
+sudo docker run --rm --mount ${MOUNT_RVT} --mount ${MOUNT_PWD} --workdir ${PWD} ${X11} -it rvt_r2ct:latest $*

--- a/docker/rust2calltree/Dockerfile
+++ b/docker/rust2calltree/Dockerfile
@@ -1,0 +1,24 @@
+FROM rvt:latest
+
+# Placeholder args that are expected to be passed in at image build time.
+# See https://code.visualstudio.com/docs/remote/containers-advanced#_creating-a-nonroot-user
+ARG USERNAME=user-name-goes-here
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Install more packages
+USER root
+RUN apt-get --yes update \
+  && apt-get install --no-install-recommends --yes \
+  dbus-x11 \
+  kcachegrind \
+  # Cleanup
+  && apt-get clean
+
+# Switch back to unprivileged user
+USER ${USERNAME}
+WORKDIR ${USER_HOME}
+ENV USER=${USERNAME}
+
+COPY --chown=${USER_UID}:${USER_GID} ./rust2calltree ${USER_HOME}/rust2calltree
+RUN cargo install --root=${USER_HOME} --path=${USER_HOME}/rust2calltree

--- a/rust2calltree/Cargo.toml
+++ b/rust2calltree/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "rust2calltree"
+version = "0.1.0"
+authors = [
+        "Alastair Reid <adreid@google.com>"
+	]
+edition = "2018"
+
+license = "MIT OR Apache-2.0"
+
+description = "Convert Rust-derived profiles to kcachegrind's calltree input format by demangling function names"
+
+repository = "https://github.com/project-oak/rust-verification-tools/"
+keywords = ["profiling, kcachegrind"]
+categories = ["command-line-utilities", "development-tools"]
+
+[dependencies]
+anyhow = "1.0"	
+log = "0.4"
+rustc-demangle = "0.1"
+stderrlog = "0.5"
+structopt = "0.3"
+
+[[bin]]
+name = "rust2calltree"
+

--- a/rust2calltree/src/main.rs
+++ b/rust2calltree/src/main.rs
@@ -1,0 +1,77 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use anyhow::{Context, Result};
+use log::info;
+use rustc_demangle::demangle;
+use std::fs::File;
+use std::io::{prelude::*, BufReader, BufWriter};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+// Command line argument parsing
+#[derive(StructOpt)]
+#[structopt(
+    name = "rust2calltree",
+    about = "Convert Rust-derived profiles to kcachegrind's calltree input format by demangling function names"
+)]
+struct Opt {
+    /// Input file.
+    #[structopt(name = "INPUT", parse(from_os_str))]
+    input: PathBuf,
+
+    /// Output file
+    #[structopt(
+        short,
+        long,
+        name = "OUTPUT",
+        parse(from_os_str),
+        default_value = "callgrind.out"
+    )]
+    output: PathBuf,
+
+    /// Increase message verbosity
+    #[structopt(short, long, parse(from_occurrences))]
+    verbosity: usize,
+}
+
+fn main() -> Result<()> {
+    let opt = Opt::from_args();
+
+    #[rustfmt::skip]
+    stderrlog::new()
+        .verbosity(opt.verbosity)
+        .init()
+        .unwrap();
+
+    // Open the input file
+    let input = opt.input.to_str().unwrap();
+    info!("Reading input from {}", input);
+    let input = File::open(input)
+        .with_context(|| format!("can't open input file '{}'", input))?;
+    let input = BufReader::new(input);
+
+    // Open the output file
+    let output = opt.output.to_str().unwrap();
+    info!("Writing demangled output to {}", output);
+    let output = File::create(&output)
+        .with_context(|| format!("can't open output file '{}'", output))?;
+    let mut output = BufWriter::new(&output);
+
+    for line in input.lines() {
+        let mut line = line?;
+        if let Some(s) = line.strip_prefix("fn=") {
+            line = format!("fn={:#}", demangle(s));
+        } else if let Some(s) = line.strip_prefix("cfn=") {
+            line = format!("cfn={:#}", demangle(s));
+        }
+        writeln!(output, "{}", line)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Consists of:

- rust2calltree program fixes name mangling in KLEE's kleeout/run.istats files
  (It should also be useful if you use any other coverage/profiling app with Rust code - but not tested that yet)
- Extend docker image with kcachegrind and prebuild rust2calltree