### PR TITLE
Rust cargo verify

### DIFF
--- a/cargo-verify/Cargo.toml
+++ b/cargo-verify/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "cargo-verify"
+version = "0.1.0"
+authors = ["Shaked Flur <sflur@google.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cargo_metadata = "0.12.3"
+glob = "0.3.0"
+lazy_static = "1.4.0"
+log  = "0.4"
+num_cpus = "1.0"
+rayon = "1.5.0"
+regex = "1.4.3"
+rustc-demangle = "0.1"
+shell-escape = "0.1.5"
+stderrlog = "0.5"
+structopt = "0.3"

--- a/cargo-verify/rustfmt.toml
+++ b/cargo-verify/rustfmt.toml
@@ -1,0 +1,11 @@
+# See more keys and their definitions at https://rust-lang.github.io/rustfmt
+
+# Use unstable features of rustfmt
+unstable_features = true
+
+merge_imports = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+
+enum_discrim_align_threshold = 20
+struct_field_align_threshold = 20

--- a/cargo-verify/src/backends_common.rs
+++ b/cargo-verify/src/backends_common.rs
@@ -1,0 +1,35 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use lazy_static::lazy_static;
+use log::info;
+use regex::Regex;
+
+/// Detect lines that match #[should_panic(expected = ...)] string.
+pub fn is_expected_panic(line: &str, expect: &Option<&str>, name: &str) -> bool {
+    lazy_static! {
+        static ref PANICKED: Regex = Regex::new(r" panicked at '([^']*)',\s+(.*)").unwrap();
+    }
+
+    if let Some(expect) = expect {
+        if let Some(caps) = PANICKED.captures(line) {
+            let message = caps.get(1).unwrap().as_str();
+            let srcloc = caps.get(2).unwrap().as_str();
+            if message.contains(expect) {
+                info!(
+                    "     {}: Detected expected failure '{}' at {}",
+                    name, message, srcloc
+                );
+                info!("     Error message: {}", line);
+                return true;
+            }
+        }
+    }
+
+    false
+}

--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -1,0 +1,322 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{collections::HashMap, ffi::OsString, fs, path::Path, process::Command};
+
+use lazy_static::lazy_static;
+use log::{info, warn};
+use regex::Regex;
+
+use crate::{utils::Append, *};
+
+/// Check if Klee is avilable.
+pub fn check_install() -> bool {
+    let output = Command::new("which").arg("klee").output().ok();
+
+    match output {
+        Some(output) => output.status.success(),
+        None => false,
+    }
+}
+
+/// Run Klee and replay
+pub fn verify(opt: &Opt, name: &str, entry: &str, bcfile: &Path) -> CVResult<Status> {
+    let out_dir = opt.cargo_toml.with_file_name("kleeout").append(name);
+
+    // Ignoring result. We don't care if it fails because the path doesn't
+    // exist.
+    fs::remove_dir_all(&out_dir).unwrap_or_default();
+    if out_dir.exists() {
+        Err(format!(
+            "Directory or file '{}' already exists, and can't be removed",
+            out_dir.to_string_lossy()
+        ))?
+    }
+
+    info!("     Running KLEE to verify {}", name);
+    info!("      file: {}", bcfile.to_string_lossy());
+    info!("      entry: {}", entry);
+    info!("      results: {}", out_dir.to_string_lossy());
+
+    let (status, stats) = run(&opt, &name, &entry, &bcfile, &out_dir)?;
+    if !stats.is_empty() {
+        match stats.get("completed paths") {
+            Some(n) => info!("     {}: {} paths", name, n),
+            None => (),
+        }
+        info!("     {}: {:?}", name, stats);
+    }
+
+    // {out_dir}/test*.err
+    let mut failures =
+        glob(&glob::Pattern::escape(out_dir.to_str().ok_or("not UTF-8")?).append("/test*.err"))?
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>();
+    failures.sort_unstable();
+    info!("      Failing test: {:?}", failures);
+
+    if opt.replay > 0 {
+        // use -r -r to see all tests, not just failing tests
+        let mut ktests = if opt.replay > 1 {
+            // {out_dir}/test*.ktest
+            glob(
+                &glob::Pattern::escape(out_dir.to_str().ok_or("not UTF-8")?).append("/test*.ktest"),
+            )?
+            .filter_map(Result::ok)
+            .collect::<Vec<_>>()
+        } else {
+            // Remove the '.err' extension and replace the '.*' ('.abort' or
+            // '.ptr') with '.ktest'.
+            failures
+                .iter()
+                .map(|p| {
+                    p.with_extension("") // Remove '.err'
+                        .with_extension("ktest") // Replace '.*' with '.ktest'
+                })
+                .collect::<Vec<_>>()
+        };
+        ktests.sort_unstable();
+
+        for ktest in ktests {
+            println!("    Test input {}", ktest.to_str().unwrap_or("???"));
+            match replay_klee(&opt, &name, &ktest) {
+                Ok(()) => (),
+                Err(err) => warn!("Failed to replay: {}", err),
+            }
+        }
+    }
+
+    Ok(status)
+}
+
+/// Return an int indicating importance of a line from KLEE's output
+/// Low numbers are most important, high numbers least important
+///
+/// -1: script error (always shown)
+/// 1: brief description of error
+/// 2: long details about an error
+/// 3: warnings
+/// 4: non-KLEE output
+/// 5: any other KLEE output
+fn importance(line: &str, expect: &Option<&str>, name: &str) -> i8 {
+    if line.starts_with("VERIFIER_EXPECT:") {
+        4
+    } else if backends_common::is_expected_panic(&line, &expect, &name) {
+        // low priority because we report it directly
+        5
+    } else if line.contains("assertion failed") {
+        1
+    } else if line.contains("verification failed") {
+        1
+    } else if line.contains("with overflow") {
+        1
+    } else if line.starts_with("KLEE: ERROR: Could not link") {
+        -1
+    } else if line.starts_with("KLEE: ERROR: Unable to load symbol") {
+        -1
+    } else if line.starts_with("KLEE: ERROR:") {
+        2
+    } else if line.starts_with("warning: Linking two modules of different data layouts") {
+        4
+    } else if line.contains("KLEE: WARNING:") {
+        4
+    } else if line.contains("KLEE: WARNING ONCE:") {
+        4
+    } else if line.starts_with("KLEE: output directory") {
+        5
+    } else if line.starts_with("KLEE: Using") {
+        5
+    } else if line.starts_with("KLEE: NOTE: Using POSIX model") {
+        5
+    } else if line.starts_with("KLEE: done:") {
+        5
+    } else if line.starts_with("KLEE: HaltTimer invoked") {
+        5
+    } else if line.starts_with("KLEE: halting execution, dumping remaining states") {
+        5
+    } else if line.starts_with("KLEE: NOTE: now ignoring this error at this location") {
+        5
+    } else if line.starts_with("KLEE:") {
+        // Really high priority to force me to categorize it
+        0
+    } else {
+        // Remaining output is probably output from the application, stack dumps, etc.
+        3
+    }
+}
+
+/// Run Klee and analyse its output.
+fn run(
+    opt: &Opt,
+    name: &str,
+    entry: &str,
+    bcfile: &Path,
+    out_dir: &Path,
+) -> CVResult<(Status, HashMap<String, isize>)> {
+    let (_, stderr, _) = Command::new("klee")
+        .args(&[
+            "--exit-on-error",
+            "--entry-point",
+            entry,
+            // "--posix-runtime",
+            // "--libcxx",
+            "--libc=klee",
+            "--silent-klee-assume",
+            "--disable-verify", // workaround https://github.com/klee/klee/issues/937
+        ])
+        .arg("--output-dir")
+        .arg(out_dir)
+        .args(&opt.backend_flags)
+        .arg(bcfile)
+        .args(&opt.args)
+        // .current_dir(&opt.crate_dir);
+        .latin1_output_info_ignore_exit()?;
+
+    // We scan stderr for:
+    // 1. Indications of the expected output (eg from #[should_panic])
+    // 2. Indications of success/failure
+    // 3. Information relevant at the current level of verbosity
+    // 4. Statistics
+
+    // Scan for expectation message
+    let mut expect = None;
+    for l in stderr.lines() {
+        if l == "VERIFIER_EXPECT: should_panic" {
+            expect = Some("");
+        } else if let Some(e) = l
+            .strip_prefix("VERIFIER_EXPECT: should_panic(expected = \"")
+            .and_then(|l| l.strip_suffix("\")"))
+        {
+            info!("Expecting '{}'", e);
+            expect = Some(e);
+        }
+    }
+
+    // Scan for first message that indicates result
+    let status = stderr
+        .lines()
+        .find_map(|l| {
+            if l.starts_with("KLEE: HaltTimer invoked") {
+                Some(Status::Timeout)
+            } else if l.starts_with("KLEE: halting execution, dumping remaining states") {
+                Some(Status::Timeout)
+            } else if l.starts_with("KLEE: ERROR: Could not link") {
+                Some(Status::Unknown)
+            } else if l.starts_with("KLEE: ERROR: Unable to load symbol") {
+                Some(Status::Unknown)
+            } else if l.starts_with("KLEE: ERROR:") && l.contains("unreachable") {
+                Some(Status::Reachable)
+            } else if l.starts_with("KLEE: ERROR:") && l.contains("overflow") {
+                Some(Status::Overflow)
+            } else if l.starts_with("KLEE: ERROR:") {
+                Some(Status::Error)
+            } else if l.starts_with("VERIFIER_EXPECT:") {
+                // don't confuse this line with an error!
+                None
+            } else if backends_common::is_expected_panic(&l, &expect, &name) {
+                Some(Status::Verified)
+            } else if l.contains("assertion failed") {
+                Some(Status::Error)
+            } else if l.contains("verification failed") {
+                Some(Status::Error)
+            } else if l.contains("with overflow") {
+                Some(Status::Overflow)
+            } else if l.contains("note: run with `RUST_BACKTRACE=1`") {
+                Some(Status::Error)
+            } else if l.contains("KLEE: done:") {
+                match expect {
+                    None => Some(Status::Verified),
+                    _ => Some(Status::Error),
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            warn!("Unable to determine status of {}", name);
+            Status::Unknown
+        });
+
+    info!(
+        "Status: '{}' expected: '{:?}'",
+        status,
+        expect
+    );
+
+    // Scan for statistics
+    lazy_static! {
+        static ref KLEE_DONE: Regex = Regex::new(r"^KLEE: done:\s+(.*)= (\d+)").unwrap();
+    }
+
+    let stats: HashMap<String, isize> = stderr
+        .lines()
+        // .filter(|l| l.starts_with("KLEE: done:"))
+        .filter_map(|l| {
+            KLEE_DONE.captures(l).and_then(|caps| {
+                // If the value doesn't parse we throw the line.
+                caps.get(2)
+                    .unwrap()
+                    .as_str()
+                    .parse::<isize>()
+                    .ok()
+                    .map(|v| (caps.get(1).unwrap().as_str().trim().to_string(), v))
+            })
+        })
+        .collect();
+
+    for l in stderr.lines() {
+        if importance(&l, &expect, &name) < opt.verbose as i8 {
+            println!("{}", l);
+        }
+    }
+
+    Ok((status, stats))
+}
+
+/// Replay a KLEE "ktest" file
+fn replay_klee(opt: &Opt, name: &str, ktest: &Path) -> CVResult<()> {
+    let mut cmd = Command::new("cargo");
+
+    if opt.tests || !opt.test.is_empty() {
+        cmd.arg("test")
+            .arg("--manifest-path").arg(&opt.cargo_toml);
+
+        if !opt.features.is_empty() {
+            cmd.arg("--features").arg(opt.features.join(","));
+        }
+
+        cmd.arg(&name).args(&["--", "--nocapture"]);
+    } else {
+        cmd.arg("run")
+            .arg("--manifest-path").arg(&opt.cargo_toml);
+
+        if !opt.features.is_empty() {
+            cmd.arg("--features").arg(opt.features.join(","));
+        }
+
+        if !opt.args.is_empty() {
+            cmd.arg("--").args(opt.args.iter());
+        }
+    }
+
+    let rustflags = match std::env::var_os("RUSTFLAGS") {
+        Some(env_rustflags) => env_rustflags.append(" --cfg=verify"),
+        None => OsString::from("--cfg=verify"),
+    };
+    cmd.env("RUSTFLAGS", rustflags).env("KTEST_FILE", ktest);
+
+    // Note that we do not treat this as an error, because
+    // the interesting case for replay is when KLEE had found an error.
+    let (stdout, stderr, _success) = cmd.output_info_ignore_exit()?;
+
+    for line in stdout.lines().chain(stderr.lines()) {
+        println!("{}", line);
+    }
+
+    Ok(())
+}

--- a/cargo-verify/src/main.rs
+++ b/cargo-verify/src/main.rs
@@ -1,0 +1,677 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(command_access)]
+
+use std::{
+    collections::HashSet,
+    error, fmt,
+    path::{Path, PathBuf},
+    process::{exit, Command},
+    str::from_utf8,
+};
+
+use cargo_metadata::{CargoOpt, MetadataCommand};
+use glob::glob;
+use lazy_static::lazy_static;
+use log::error;
+use rayon::prelude::*;
+use regex::Regex;
+use rustc_demangle::demangle;
+use structopt::{clap::arg_enum, StructOpt};
+use utils::{add_pre_ext, Append};
+
+// utils must come before the other modules as it defines macros that they might
+// use.
+#[macro_use]
+mod utils;
+
+mod backends_common;
+mod klee;
+mod proptest;
+mod run_tools;
+mod seahorn;
+
+use run_tools::*;
+
+// Command line arguments
+#[derive(StructOpt)]
+#[structopt(
+    name = "cargo-verify",
+    about = "Execute verification tools",
+    // version number is taken automatically from Cargo.toml
+)]
+pub struct Opt {
+    // TODO: make this more like 'cargo test --manifest-path <PATH>'
+    // (i.e., path to Cargo.toml)
+    /// Path to Cargo.toml
+    #[structopt(
+        long = "manifest-path",
+        name = "PATH",
+        parse(from_os_str),
+        default_value = "Cargo.toml"
+    )]
+    cargo_toml: PathBuf,
+
+    /// Arguments to pass to program under test
+    #[structopt(name = "ARG", last = true)]
+    args: Vec<String>,
+
+    // backend_arg is used for holding the CL option. After parsing, if the user
+    // specified a backend it will be copied to the `backend` field below, if
+    // the user didn't specify a backend, we will auto-detect one, and put it
+    // in the `backend` field.
+    /// Select verification backend
+    #[structopt(
+        short = "b",
+        long = "backend",
+        name = "BACKEND",
+        possible_values = &Backend::variants(),
+        case_insensitive = true,
+    )]
+    backend_arg: Option<Backend>,
+
+    // See the comment of `backend_arg` above.
+    #[structopt(skip = Backend::Klee)] // the initial value has no meaning, it will be overwritten
+    backend: Backend,
+
+    /// Extra verification flags
+    #[structopt(long, number_of_values = 1, use_delimiter = true)]
+    backend_flags: Vec<String>,
+
+    /// Space or comma separated list of features to activate
+    #[structopt(long, name = "FEATURES", number_of_values = 1, use_delimiter = true)]
+    features: Vec<String>,
+
+    /// Run `cargo clean` first
+    #[structopt(short, long)]
+    clean: bool,
+
+    /// Verify all tests instead of 'main'
+    #[structopt(short, long)]
+    tests: bool,
+
+    // TODO: make this more like 'cargo test [TESTNAME]'
+    /// Only verify tests containing this string in their names
+    #[structopt(long, number_of_values = 1, name = "TESTNAME")]
+    test: Vec<String>,
+
+    // jobs_arg is used for holding the CL option. After parsing, if the user
+    // specified a value it will be copied to the `jobs` field below, if the
+    // user didn't specify a value, we will use num_cpus, and put it in the
+    // `jobs` field.
+    /// Number of parallel jobs, defaults to # of CPUs
+    #[structopt(short = "j", long = "jobs", name = "N")]
+    jobs_arg: Option<usize>,
+
+    // See the comment of `jobs_arg` above.
+    #[structopt(skip)]
+    jobs: usize,
+
+    /// Replay to display concrete input values
+    #[structopt(short, long, parse(from_occurrences))]
+    replay: usize,
+
+    /// Use verbose output (-vvvvvv very verbose output)
+    #[structopt(short, long, parse(from_occurrences))]
+    verbose: usize,
+}
+
+arg_enum! {
+    #[derive(Debug, PartialEq, Copy, Clone)]
+    enum Backend {
+        Proptest,
+        Klee,
+        Seahorn,
+    }
+}
+
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Status {
+    Unknown, // E.g. the verifier failed to execute.
+    Verified,
+    Error, // E.g. the verifier found a violation.
+    Timeout,
+    Overflow,
+    Reachable,
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Status::Unknown => write!(f, "UNKNOWN"),
+            Status::Verified => {
+                if f.alternate() {
+                    // "{:#}"
+                    write!(f, "OK")
+                } else {
+                    // "{}"
+                    write!(f, "VERIFIED")
+                }
+            }
+            Status::Error => write!(f, "ERROR"),
+            Status::Timeout => write!(f, "TIMEOUT"),
+            Status::Overflow => write!(f, "OVERFLOW"),
+            Status::Reachable => write!(f, "REACHABLE"),
+        }
+    }
+}
+
+type CVResult<T> = Result<T, Box<dyn error::Error>>;
+
+/// Parse the command line and make sure it makes sense.
+fn process_command_line() -> CVResult<Opt> {
+    // cargo-verify can be called directly, or by placing it on the `PATH` and
+    // calling it through `cargo` (i.e. `cargo verify ...`.
+    let mut args: Vec<_> = std::env::args().collect();
+    if args.get(1).map(AsRef::as_ref) == Some("verify") {
+        // Looks like the script was invoked by `cargo verify` - we have to
+        // remove the second argument.
+        args.remove(1);
+    }
+    let mut opt = Opt::from_iter(args.into_iter());
+    // let mut opt = Opt::from_args();
+
+    opt.backend = match opt.backend_arg {
+        // Check if the backend that was specified on the CL is installed.
+        Some(Backend::Proptest) => {
+            assert!(proptest::check_install());
+            Backend::Proptest
+        }
+        Some(Backend::Klee) => {
+            if !klee::check_install() {
+                Err("Klee is not installed")?;
+            }
+            Backend::Klee
+        }
+        Some(Backend::Seahorn) => {
+            if !seahorn::check_install() {
+                Err("Seahorn is not installed")?;
+            }
+            Backend::Seahorn
+        }
+        None => {
+            // If the user did not specify a backend, use the first one that we find.
+            let backend = if klee::check_install() {
+                Backend::Klee
+            } else if seahorn::check_install() {
+                Backend::Seahorn
+            } else {
+                assert!(proptest::check_install());
+                Backend::Proptest
+            };
+            println!("Using {} as backend", backend);
+            backend
+        }
+    };
+
+    // To be compatible with `cargo test`, features might be space separated.
+    opt.features = opt
+        .features
+        .iter()
+        .flat_map(|s| s.split(' '))
+        .map(String::from)
+        .collect::<Vec<_>>();
+
+    // Backend specific options.
+    match opt.backend {
+        Backend::Proptest => {
+            if opt.replay > 0 && !opt.args.is_empty() {
+                Err("The Proptest backend does not support '--replay' and passing arguments together.")?;
+            }
+        }
+        Backend::Seahorn => {
+            if !opt.args.is_empty() {
+                Err("The Seahorn backend does not support passing arguments yet.")?;
+            }
+            if opt.replay != 0 {
+                Err("The Seahorn backend does not support '--replay' yet.")?;
+            }
+
+            opt.features.push(String::from("verifier-seahorn"));
+        }
+        Backend::Klee => {
+            opt.features.push(String::from("verifier-klee"));
+        }
+    }
+
+    // Use the user specified number of jobs, or the number of CPUs.
+    opt.jobs = opt.jobs_arg.unwrap_or(num_cpus::get());
+
+    Ok(opt)
+}
+
+/// Invoke a checker (verifier or fuzzer) on a crate.
+fn main() -> CVResult<()> {
+    let opt = process_command_line()?;
+    stderrlog::new().verbosity(opt.verbose).init()?;
+
+    if opt.clean {
+        clean(&opt);
+    }
+
+    let package = get_meta_package_name(&opt)?;
+    info_at!(&opt, 1, "Checking {}", &package);
+
+    let status = match opt.backend {
+        Backend::Proptest => {
+            info_at!(&opt, 1, "  Invoking cargo run with proptest backend");
+            proptest::run(&opt)
+        }
+        _ => {
+            let target = get_default_host(&opt.cargo_toml.parent().unwrap_or(&PathBuf::from(".")))?;
+            info_at!(&opt, 4, "target: {}", target);
+            verify(&opt, &package, &target)
+        }
+    }
+    .unwrap_or_else(|err| {
+        error!("{}", err);
+        exit(1)
+    });
+
+    println!("VERIFICATION_RESULT: {}", status);
+    if status != Status::Verified {
+        exit(1);
+    }
+    Ok(())
+}
+
+/// Compile a Rust crate to generate bitcode and run one of the LLVM verifier
+/// backends on the result.
+fn verify(opt: &Opt, package: &str, target: &str) -> CVResult<Status> {
+    // Compile and link the patched file using LTO to generate the entire
+    // application in a single LLVM file
+    info_at!(&opt, 1, "  Building {} for verification", package);
+    let bcfile = build(&opt, &package, &target)?;
+
+    // Get the functions we need to verify, and their mangled names.
+    let tests = if opt.tests || !opt.test.is_empty() {
+        // If using the --tests or --test flags, generate a list of tests and
+        // their mangled names.
+        info_at!(&opt, 3, "  Getting list of tests in {}", &package);
+        let mut tests = list_tests(&opt, &target)?;
+        if !opt.test.is_empty() {
+            tests = tests
+                .into_iter()
+                .filter(|t| opt.test.iter().any(|f| t.contains(f)))
+                .collect();
+        }
+        if tests.is_empty() {
+            Err("  No tests found")?
+        }
+        let tests: Vec<String> = tests
+            .iter()
+            .map(|t| format!("{}::{}", package, t))
+            .collect();
+
+        // then look up their mangled names in the bcfile
+        mangle_functions(&opt, &bcfile, &tests)?
+    } else if opt.backend == Backend::Seahorn {
+        // Find the entry function (mangled main)
+        let mains = mangle_functions(&opt, &bcfile, &[String::from(package) + "::main"])?;
+        match mains.as_slice() {
+            [(_, _)] => mains,
+            [] => Err("  FAILED: can't find the 'main' function")?,
+            _ => Err("  FAILED: found more than one 'main' function")?,
+        }
+    } else {
+        vec![("main".to_string(), "main".to_string())]
+    };
+
+    // Remove the package name from the function names (important for Klee?) in tests.
+    let tests: Vec<_> = tests
+        .into_iter()
+        .map(|(name, mangled)| {
+            if let Some(name) = name.strip_prefix(&format!("{}::", package)) {
+                (name.to_string(), mangled)
+            } else {
+                (name, mangled)
+            }
+        })
+        .collect();
+
+    #[rustfmt::skip]
+    info_at!(&opt, 1, "  Checking {}",
+             tests.iter().cloned().unzip::<_, _, Vec<_>, Vec<_>>().0.join(", ")
+    );
+    info_at!(opt, 4, "Mangled: {:?}", tests);
+
+    // For each test function, we run the backend and sift through its
+    // output to generate an appropriate status string.
+    println!("Running {} test(s)", tests.len());
+
+    let results: Vec<Status> = if opt.jobs > 1 {
+        // Run the verification in parallel.
+
+        // `build_global` must not be called more than once!
+        // This call configures the thread-pool for `par_iter` below.
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(opt.jobs)
+            .build_global()?;
+
+        tests
+            .par_iter() // <- parallelised iterator
+            .map(|(name, entry)| verifier_run(&opt, &bcfile, &name, &entry))
+            .collect()
+    } else {
+        // Same as above but without the overhead of rayon
+        tests
+            .iter() // <- this is the only difference
+            .map(|(name, entry)| verifier_run(&opt, &bcfile, &name, &entry))
+            .collect()
+    };
+
+    // Count pass/fail
+    let passes = results.iter().filter(|r| **r == Status::Verified).count();
+    let fails = results.len() - passes;
+    // randomly pick one failing status (if any)
+    let status = results
+        .into_iter()
+        .find(|r| *r != Status::Verified)
+        .unwrap_or(Status::Verified);
+
+    println!(
+        "test result: {:#}. {} passed; {} failed",
+        status, passes, fails
+    );
+    Ok(status)
+}
+
+/// Invoke one of the supported verification backends on entry point 'entry'
+/// (with pretty name 'name') in bitcodefile 'bcfile'.
+fn verifier_run(opt: &Opt, bcfile: &Path, name: &str, entry: &str) -> Status {
+    let status = match opt.backend {
+        Backend::Klee => klee::verify(&opt, &name, &entry, &bcfile),
+        Backend::Seahorn => seahorn::verify(&opt, &name, &entry, &bcfile),
+        Backend::Proptest => unreachable!(),
+    }
+    .unwrap_or_else(|err| {
+        error!("{}", err);
+        error!("Failed to run test '{}'.", name);
+        Status::Unknown
+    });
+
+    println!("test {} ... {:#}", name, status);
+    status
+}
+
+/// Compile, link and do transformations on LLVM bitcode.
+fn build(opt: &Opt, package: &str, target: &str) -> CVResult<PathBuf> {
+    let (mut bc_file, c_files) = compile(&opt, &package, target)?;
+
+    // Link bc file (from all the Rust code) against the c_files from
+    // any C/C++ code generated by build scripts
+    if !c_files.is_empty() {
+        let new_bc_file = add_pre_ext(&bc_file, "link");
+        info_at!(
+            &opt,
+            3,
+            "  Linking {} and [{}] to produce {}",
+            bc_file.to_string_lossy(),
+            c_files
+                .iter()
+                .map(|p| p.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(", "),
+            new_bc_file.to_string_lossy()
+        );
+        // Link multiple bitcode files together.
+        Command::new("llvm-link")
+            .arg("-o")
+            .arg(&new_bc_file)
+            .arg(&bc_file)
+            .args(&c_files)
+            .output_info()?;
+        bc_file = new_bc_file;
+    }
+
+    if opt.backend == Backend::Seahorn {
+        info_at!(&opt, 1, "  Patching LLVM file for Seahorn");
+        let new_bc_file = add_pre_ext(&bc_file, "patch-sea");
+        patch_llvm(&opt, &["--seahorn"], &bc_file, &new_bc_file)?;
+        bc_file = new_bc_file;
+    }
+
+    if !opt.args.is_empty() {
+        info_at!(&opt, 1, "  Patching LLVM file for initializers");
+        let new_bc_file = add_pre_ext(&bc_file, "patch-init-feat");
+        patch_llvm(
+            &opt,
+            &["--initializers", "--features"],
+            &bc_file,
+            &new_bc_file,
+        )?;
+        bc_file = new_bc_file;
+    }
+
+    Ok(bc_file)
+}
+
+/// Return the environment variables needed for building.  Each item in the
+/// vector is a pair `(a, b)` where `a` is the variable name and `b` is its
+/// value.
+fn get_build_envs(opt: &Opt) -> CVResult<Vec<(String, String)>> {
+    let mut rustflags = vec![
+        "-Clto", // Generate linked bitcode for entire crate
+        "-Cembed-bitcode=yes",
+        "--emit=llvm-bc",
+        // Any value except 0 seems to work
+        "--cfg=verify", // Select verification versions of libraries
+        // "-Ccodegen-units=1",     // Optimize a bit more?
+        "-Zpanic_abort_tests", // Panic abort is simpler
+        "-Cpanic=abort",
+        "-Warithmetic-overflow", // Detecting errors is good!
+        "-Coverflow-checks=yes",
+        "-Cno-vectorize-loops", // KLEE does not support vector intrinisics
+        "-Cno-vectorize-slp",
+        "-Ctarget-feature=-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2",
+        // use clang to link with LTO - to handle calls to C libraries
+        "-Clinker-plugin-lto",
+        "-Clinker=clang-10",
+        "-Clink-arg=-fuse-ld=lld",
+    ]
+    .join(" ");
+
+    if opt.backend != Backend::Seahorn {
+        // Avoid generating SSE instructions
+        rustflags.push_str(" -Copt-level=1");
+    }
+
+    match std::env::var_os("RUSTFLAGS") {
+        Some(env) => {
+            rustflags.push_str(" ");
+            rustflags.push_str(env.to_str().ok_or("not UTF-8")?);
+        }
+        None => (),
+    };
+
+    Ok(vec![
+        (String::from("RUSTFLAGS"), rustflags),
+        (String::from("CRATE_CC_NO_DEFAULTS"), String::from("true")),
+        (String::from("CFLAGS"), String::from("-flto=thin")),
+        (String::from("CC"), String::from("clang-10")),
+    ])
+}
+
+/// Compile a crate for verification.
+/// Return a bcfile for the entire (linked) crate, and c object files that need
+/// to be linked with the bcfile.
+fn compile(opt: &Opt, package: &str, target: &str) -> CVResult<(PathBuf, Vec<PathBuf>)> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build").arg("--manifest-path").arg(&opt.cargo_toml);
+
+    if !opt.features.is_empty() {
+        cmd.arg("--features").arg(opt.features.join(","));
+    }
+
+    if opt.tests || !opt.test.is_empty() {
+        cmd.arg("--tests");
+    }
+
+    // The following line is not present because we care about the target It is
+    // there to allow us to use -Clto to build crates whose dependencies invoke
+    // proc_macros.
+    // FIXME: "=="?
+    cmd.arg(format!("--target={}", target))
+        .args(vec!["-v"; opt.verbose])
+        .envs(get_build_envs(&opt)?)
+        .output_info()?;
+    // .env("PATH", ...)
+
+    // Find the target directory
+    // (This may not be inside the crate if using workspaces)
+    info_at!(&opt, 4, "  Getting target directory");
+    let target_dir = get_meta_target_directory(&opt)?;
+
+    // {target_dir}/{target}/debug/deps/{package}*.bc
+    // where the file name has exactly one 1 '.' (because later we add similar
+    // files, with multiple dots, and we don't want them here)
+    // and the file has a main function.
+    let bc_files = glob(
+        &glob::Pattern::escape(
+            target_dir
+                .clone()
+                .append(target)
+                .append("debug")
+                .append("deps")
+                .append(package)
+                .to_str()
+                .ok_or("not UTF-8")?,
+        )
+        .append("*.bc"),
+    )?
+    .filter_map(Result::ok)
+    // Filter only files that have exactly one '.'
+    .filter(|p| p.file_name().map(|f| f.to_string_lossy().matches('.').count() == 1).unwrap_or(false))
+    .filter(|p| count_symbols(&opt, p, &["main", "_main"]).map_or(false, |c| c > 0))
+    .collect::<Vec<_>>();
+
+    // Make sure there is only one such file.
+    let bc_file: PathBuf = match bc_files.as_slice() {
+        [_] => {
+            // Move element 0 out of the Vec (and into `bcfile`).
+            (bc_files as Vec<_>).remove(0)
+        }
+        [] => {
+            if opt.tests || !opt.test.is_empty() {
+                Err("  FAILED: Use --tests with library crates")?
+            } else {
+                Err(format!("  FAILED: Test {} compilation error", &package))?
+            }
+        }
+        _ => {
+            error!(
+                "    Ambiguous bitcode files {}",
+                bc_files
+                    .iter()
+                    .map(|p| p.to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            Err(format!("  FAILED: Test {} compilation error", &package))?
+        }
+    };
+
+    // {targetdir}/{target}/debug/build/ * /out/ *.o"
+    let c_files = glob(
+        &glob::Pattern::escape(
+            target_dir
+                .clone()
+                .append(target)
+                .append("debug")
+                .append("build")
+                .to_str()
+                .ok_or("not UTF-8")?,
+        )
+        .append("/*/out/*.o"),
+    )?
+    .filter_map(Result::ok)
+    .collect::<Vec<_>>();
+
+    // build_plan = read_build_plan(crate, flags)
+    // print(json.dumps(build_plan, indent=4, sort_keys=True))
+    Ok((bc_file, c_files))
+}
+
+/// Patch LLVM file to enable verification
+///
+/// Some of the patching performed includes:
+/// - arranging for initializers to be executed (this makes std::env::args()
+///   work)
+/// - redirecting panic! to invoke backend-specific intrinsic functions for
+///   reporting errors
+fn patch_llvm(opt: &Opt, options: &[&str], bcfile: &Path, new_bcfile: &Path) -> CVResult<()> {
+    Command::new("rvt-patch-llvm")
+        .arg(bcfile)
+        .arg("-o")
+        .arg(new_bcfile)
+        .args(options)
+        .args(vec!["-v"; opt.verbose])
+        .output_info()?;
+    Ok(())
+}
+
+/// Find a function defined in LLVM bitcode file.
+/// Demangle all the function names, and compare tham to `names`.
+fn mangle_functions(
+    opt: &Opt,
+    bcfile: &Path,
+    names: &[impl AsRef<str>],
+) -> CVResult<Vec<(String, String)>> {
+    let names: HashSet<&str> = names.iter().map(AsRef::as_ref).collect();
+
+    info_at!(
+        &opt,
+        4,
+        "    Looking up {:?} in {}",
+        names,
+        bcfile.to_string_lossy()
+    );
+
+    let (stdout, _) = Command::new("llvm-nm")
+        .arg("--defined-only")
+        .arg(bcfile)
+        .output_info()?;
+
+    let rs: Vec<(String, String)> = stdout
+        .lines()
+        .map(|l| l.split(" ").collect::<Vec<&str>>())
+        .filter_map(|l| {
+            if l.len() == 3
+                && l[1].to_lowercase() == "t"
+                && (l[2].starts_with("__ZN") || l[2].starts_with("_ZN"))
+            {
+                let mangled = if l[2].starts_with("__ZN") {
+                    // on OSX, llvm-nm shows a double underscore prefix
+                    &l[2][1..]
+                } else {
+                    &l[2]
+                };
+                // The alternative format ({:#}) is without the hash at the end.
+                let dname = format!("{:#}", demangle(mangled));
+                if names.contains(dname.as_str()) {
+                    Some((dname, mangled.into()))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    info_at!(&opt, 4, "      Found {:?}", rs);
+
+    // TODO: this doesn't look right:
+    // missing = set(paths) - paths.keys()
+    let missing = names.len() - rs.len();
+    if missing > 0 {
+        Err(format!("Unable to find {} tests in bytecode file", missing))?
+    }
+    Ok(rs)
+}

--- a/cargo-verify/src/proptest.rs
+++ b/cargo-verify/src/proptest.rs
@@ -1,0 +1,62 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use log::warn;
+
+use crate::*;
+
+pub fn check_install() -> bool {
+    true
+}
+
+/// Run cargo test
+pub fn run(opt: &Opt) -> CVResult<Status> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("test")
+        .arg("--manifest-path")
+        .arg(&opt.cargo_toml)
+        .args(vec!["-v"; opt.verbose]);
+
+    if !opt.features.is_empty() {
+        cmd.arg("--features").arg(opt.features.join(","));
+    }
+
+    if opt.tests {
+        cmd.arg("--tests");
+    }
+
+    for t in &opt.test {
+        cmd.arg("--test").arg(t);
+    }
+
+    if opt.replay > 0 {
+        assert!(opt.args.is_empty());
+        cmd.arg("--").arg("--nocapture");
+    } else if !opt.args.is_empty() {
+        cmd.arg("--").args(&opt.args);
+    }
+
+    match cmd.output_info_ignore_exit() {
+        Err(e) => {
+            warn!("Proptest failed '{:?}'", e);
+            Ok(Status::Error)
+        }
+        Ok((_, stderr, success)) => {
+            if !success {
+                for l in stderr.lines() {
+                    if l.contains("with overflow") {
+                        return Ok(Status::Overflow);
+                    }
+                }
+                Ok(Status::Error)
+            } else {
+                Ok(Status::Verified)
+            }
+        }
+    }
+}

--- a/cargo-verify/src/run_tools.rs
+++ b/cargo-verify/src/run_tools.rs
@@ -1,0 +1,230 @@
+use std::{iter, str::Lines};
+
+use log::info;
+
+use crate::*;
+
+/// Trait for wrapping `std::process::Command::output()` with logging.
+pub trait OutputInfo {
+    fn output_info(&mut self) -> CVResult<(String, String)> {
+        self.output_info_helper(|v| String::from(from_utf8(v).expect("not UTF-8")), false)
+            .map(|(stdout, stderr, _)| (stdout, stderr))
+    }
+
+    fn latin1_output_info(&mut self) -> CVResult<(String, String)> {
+        self.output_info_helper(utils::from_latin1, false)
+            .map(|(stdout, stderr, _)| (stdout, stderr))
+    }
+
+    fn output_info_ignore_exit(&mut self) -> CVResult<(String, String, bool)> {
+        self.output_info_helper(|v| String::from(from_utf8(v).expect("not UTF-8")), true)
+    }
+
+    fn latin1_output_info_ignore_exit(&mut self) -> CVResult<(String, String, bool)> {
+        self.output_info_helper(utils::from_latin1, true)
+    }
+
+    fn output_info_helper(
+        &mut self,
+        trans: impl Fn(&[u8]) -> String,
+        ignore_exit: bool,
+    ) -> CVResult<(String, String, bool)>;
+}
+
+impl OutputInfo for Command {
+    fn output_info_helper(
+        &mut self,
+        trans: impl Fn(&[u8]) -> String,
+        ignore_exit: bool,
+    ) -> CVResult<(String, String, bool)> {
+        info_cmd(&self);
+
+        let output = self.output()?;
+
+        let stdout = trans(&output.stdout);
+        info_lines("STDOUT: ", stdout.lines());
+
+        let stderr = trans(&output.stderr);
+        info_lines("STDERR: ", stderr.lines());
+
+        if !ignore_exit && !output.status.success() {
+            match output.status.code() {
+                Some(code) => Err(format!(
+                    "FAILED: '{}' terminated with exit code {}.",
+                    self.get_program().to_string_lossy(),
+                    code
+                ))?,
+                None => Err(format!(
+                    "FAILED: '{}' terminated by a signal.",
+                    self.get_program().to_string_lossy()
+                ))?,
+            }
+        }
+
+        Ok((stdout, stderr, output.status.success()))
+    }
+}
+
+/// Log `cmd` nicely.
+fn info_cmd(cmd: &Command) {
+    info!(
+        "Running '{}' in '{}' with command:\n{}",
+        cmd.get_program().to_string_lossy(),
+        cmd.get_current_dir()
+            .unwrap_or(&PathBuf::from("."))
+            .to_string_lossy(),
+        iter::once(cmd.get_program())
+            .chain(cmd.get_args())
+            .map(|s| shell_escape::escape(s.to_string_lossy()))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
+    let envs = cmd.get_envs();
+    if envs.len() > 0 {
+        info!(
+            "with environment variables:\n{}",
+            envs.map(|(var, val)| match val {
+                Some(val) => format!(
+                    "{}={}",
+                    var.to_string_lossy(),
+                    shell_escape::escape(val.to_string_lossy())
+                ),
+                None => format!("{}=''", var.to_string_lossy()), // explicitly removed
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+        );
+    }
+}
+
+/// Print each line of `Lines` using `info!`, prefixed with `prefix`.
+pub fn info_lines(prefix: &str, lines: Lines) {
+    for l in lines {
+        info!("{}{}", prefix, l);
+    }
+}
+
+/// Run `cargo clean`.
+pub fn clean(opt: &Opt) {
+    info_at!(&opt, 1, "Running `cargo clean`");
+    Command::new("cargo")
+        .arg("clean")
+        .arg("--manifest-path")
+        .arg(&opt.cargo_toml)
+        .output_info_ignore_exit()
+        .ok(); // Discarding the error on purpose.
+}
+
+/// Find the name of the crate.
+pub fn get_meta_package_name(opt: &Opt) -> CVResult<String> {
+    let name = MetadataCommand::new()
+        .manifest_path(&opt.cargo_toml)
+        .features(CargoOpt::SomeFeatures(opt.features.clone()))
+        .exec()?
+        .root_package()
+        .ok_or("no root package")?
+        .name
+        .replace(
+            |c| match c {
+                // Allowed characters.
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '_' => false,
+                // Anything else will be replaced with the '_' character.
+                _ => true,
+            },
+            "_",
+        );
+
+    Ok(name)
+}
+
+/// Find the target directory.
+pub fn get_meta_target_directory(opt: &Opt) -> CVResult<PathBuf> {
+    // FIXME: add '--cfg=verify' to RUSTFLAGS?
+    let dir = MetadataCommand::new()
+        .manifest_path(&opt.cargo_toml)
+        .features(CargoOpt::SomeFeatures(opt.features.clone()))
+        .exec()?
+        .target_directory;
+
+    Ok(dir)
+}
+
+/// Get name of default_host.
+/// This is passed to cargo using "--target=..." and will be the name of the
+/// directory within the target directory.
+pub fn get_default_host(crate_path: &Path) -> CVResult<String> {
+    let mut cmd = Command::new("rustup");
+    cmd.arg("show");
+
+    if crate_path != PathBuf::from("") {
+        cmd.current_dir(crate_path);
+    }
+
+    Ok(cmd
+        .output_info()?
+        .0
+        .lines()
+        .find_map(|l| l.strip_prefix("Default host:").and_then(|l| Some(l.trim())))
+        .ok_or("Unable to determine default host")?
+        .to_string())
+}
+
+/// Count how many functions in `f`s are present in `bcfile`.
+pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
+    info_at!(
+        &opt,
+        4,
+        "    Counting symbols {:?} in {}",
+        fs,
+        bcfile.to_string_lossy()
+    );
+
+    let mut cmd = Command::new("llvm-nm");
+    cmd.arg("--defined-only").arg(bcfile);
+    let (stdout, _) = cmd.output_info()?;
+
+    let count = stdout
+        .lines()
+        .map(|l| l.split(" ").collect::<Vec<_>>())
+        .filter(|l| l.len() == 3 && l[1] == "T" && fs.iter().any(|f| f == &l[2]))
+        .count();
+
+    info_at!(&opt, 4, "    Found {} functions", count);
+    Ok(count)
+}
+
+/// Generate a list of tests in the crate by parsing the output of
+/// `cargo test -- --list`
+pub fn list_tests(opt: &Opt, target: &str) -> CVResult<Vec<String>> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("test").arg("--manifest-path").arg(&opt.cargo_toml);
+
+    if !opt.features.is_empty() {
+        cmd.arg("--features").arg(opt.features.join(","));
+    }
+
+    cmd.arg(format!("--target={}", target))
+        .args(vec!["-v"; opt.verbose])
+        .envs(get_build_envs(&opt)?)
+        .args(&["--", "--list"]);
+    // .arg("--exclude-should-panic")
+    // .env("PATH", ...)
+
+    lazy_static! {
+        static ref TEST: Regex = Regex::new(r"(\S+):\s+test\s*$").unwrap();
+    }
+
+    // TODO: Python ignores bad exit codes
+    let tests = cmd
+        .output_info()?
+        .0
+        .lines()
+        .filter_map(|l| {
+            TEST.captures(l)
+                .map(|caps| caps.get(1).unwrap().as_str().into())
+        })
+        .collect();
+
+    Ok(tests)
+}

--- a/cargo-verify/src/seahorn.rs
+++ b/cargo-verify/src/seahorn.rs
@@ -1,0 +1,178 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{ffi::OsString, fs, path::Path, process::Command};
+
+use log::{info, warn};
+
+use crate::{utils::Append, *};
+
+/// Check if Seahorn is avilable.
+pub fn check_install() -> bool {
+    // TODO: maybe it's better to check `seahorn --version`?
+    let output = Command::new("which").arg("sea").output().ok();
+
+    match output {
+        Some(output) => output.status.success(),
+        None => false,
+    }
+}
+
+/// Run Seahorn
+pub fn verify(opt: &Opt, name: &str, entry: &str, bcfile: &Path) -> CVResult<Status> {
+    let out_dir = opt.cargo_toml.with_file_name("seaout").append(name);
+
+    // Ignoring result. We don't care if it fails because the path doesn't
+    // exist.
+    fs::remove_dir_all(&out_dir).unwrap_or_default();
+    if out_dir.exists() {
+        Err(format!(
+            "Directory or file '{}' already exists, and can't be removed",
+            out_dir.to_string_lossy()
+        ))?
+    }
+    fs::create_dir_all(&out_dir)?;
+
+    info!("     Running Seahorn to verify {}", name);
+    info!("      file: {}", bcfile.to_string_lossy());
+    info!("      entry: {}", entry);
+    info!("      results: {}", out_dir.to_string_lossy());
+
+    run(&opt, &name, &entry, &bcfile, &out_dir)
+}
+
+/// Return an int indicating importance of a line from KLEE's output
+/// Low numbers are most important, high numbers least important
+///
+/// -1: script error (always shown)
+/// 1: brief description of error
+/// 2: long details about an error
+/// 3: warnings
+/// 4: non-Seahorn output
+/// 5: any other Seahorn output
+fn importance(line: &str, expect: &Option<&str>, name: &str) -> i8 {
+    if line.starts_with("VERIFIER_EXPECT:") {
+        4
+    } else if line == "sat" {
+        1
+    } else if line.starts_with("Warning: Externalizing function:")
+        || line.starts_with("Warning: not lowering an initializer for a global struct:")
+    {
+        4
+    } else if backends_common::is_expected_panic(&line, &expect, &name) || line == "unsat" {
+        5
+    } else if line.starts_with("Warning:") {
+        // Really high priority to force me to categorize it
+        0
+    } else {
+        // Remaining output is probably output from the application, stack dumps, etc.
+        3
+    }
+}
+
+/// Run Seahorn and analyse its output.
+fn run(opt: &Opt, name: &str, entry: &str, bcfile: &Path, out_dir: &Path) -> CVResult<Status> {
+    let mut cmd = Command::new("sea");
+    cmd.args(&["bpf",
+               // The following was extracted from `sea yama -y VCC/seahorn/sea_base.yaml`
+               "-O3",
+               "--inline",
+               "--enable-loop-idiom",
+               "--enable-indvar",
+               "--no-lower-gv-init-struct",
+               "--externalize-addr-taken-functions",
+               "--no-kill-vaarg",
+               "--with-arith-overflow=true",
+               "--horn-unify-assumes=true",
+               "--horn-gsa",
+               "--no-fat-fns=bcmp,memcpy,assert_bytes_match,ensure_linked_list_is_allocated,sea_aws_linked_list_is_valid",
+               "--dsa=sea-cs-t",
+               "--devirt-functions=types",
+               "--bmc=opsem",
+               "--horn-vcgen-use-ite",
+               "--horn-vcgen-only-dataflow=true",
+               "--horn-bmc-coi=true",
+               "--sea-opsem-allocator=static",
+               "--horn-explicit-sp0=false",
+               "--horn-bv2-lambdas",
+               "--horn-bv2-simplify=true",
+               "--horn-bv2-extra-widemem",
+               "--horn-stats=true",
+               "--keep-temps",
+    ]);
+
+    cmd.arg(OsString::from("--temp-dir=").append(out_dir))
+        .arg(String::from("--entry=") + entry)
+        .args(&opt.backend_flags)
+        .arg(&bcfile);
+    // .args(&opt.args)
+
+    let (stdout, stderr, _) = cmd.output_info_ignore_exit()?;
+
+    // We scan stderr for:
+    // 1. Indications of the expected output (eg from #[should_panic])
+    // 2. Indications of success/failure
+    // 3. Information relevant at the current level of verbosity
+    // 4. Statistics
+
+    // Scan for expectation message
+    let mut expect = None;
+    for l in stderr.lines() {
+        if l == "VERIFIER_EXPECT: should_panic" {
+            expect = Some("");
+        } else if let Some(e) = l
+            .strip_prefix("VERIFIER_EXPECT: should_panic(expected = \"")
+            .and_then(|l| l.strip_suffix("\")"))
+        {
+            info!("Expecting '{}'", e);
+            expect = Some(e);
+        }
+    }
+
+    // Scan for first message that indicates result
+    let status = stderr
+        .lines()
+        .chain(stdout.lines())
+        .find_map(|l| {
+            if l.starts_with("VERIFIER_EXPECT:") {
+                // don't confuse this line with an error!
+                None
+            } else if backends_common::is_expected_panic(&l, &expect, &name) {
+                Some(Status::Verified)
+            } else if l == "sat" {
+                Some(Status::Error)
+            } else if l == "unsat" {
+                match expect {
+                    None => Some(Status::Verified),
+                    _ => Some(Status::Error),
+                }
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            warn!("Unable to determine status of {}", name);
+            Status::Unknown
+        });
+
+    info!(
+        "Status: '{}' expected: '{}'",
+        status,
+        expect.unwrap_or("---")
+    );
+
+    // TODO: Scan for statistics
+
+    for l in stderr.lines() {
+        if importance(&l, &expect, &name) < opt.verbose as i8 {
+            println!("{}", l);
+        }
+    }
+
+    Ok(status)
+}

--- a/cargo-verify/src/utils.rs
+++ b/cargo-verify/src/utils.rs
@@ -1,0 +1,90 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+////////////////////////////////////////////////////////////////////////////////
+// Put here reusable general purpose utility functions (nothing that is part of
+// core functionality).
+////////////////////////////////////////////////////////////////////////////////
+
+use std::{
+    borrow::{Borrow, ToOwned},
+    ffi::{OsStr, OsString},
+    path::{Path, PathBuf},
+};
+
+/// `info_at!(&opt, level, ...)` will print the formatted message `...` if
+/// verbosity level is `level` or higher.
+macro_rules! info_at {
+    ($opt:expr, $lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $opt.verbose {
+            println!($($arg)+);
+        }
+    });
+}
+
+/// encoding_rs (https://docs.rs/encoding_rs/), seems to be the standard crate
+/// for encoding/decoding, has this to say about ISO-8859-1: "ISO-8859-1 does not
+/// exist as a distinct encoding from windows-1252 in the Encoding
+/// Standard. Therefore, an encoding that maps the unsigned byte value to the
+/// same Unicode scalar value is not available via Encoding in this crate."
+/// The following is from https://stackoverflow.com/a/28175593
+pub fn from_latin1(s: &[u8]) -> String {
+    s.iter().map(|&c| c as char).collect()
+}
+
+/// The Append trait lets you chain `append` calls where usually you would have
+/// to mutate (e.g. using `push`).
+/// Example:
+/// assert_eq!(String::from("foo").append("bar"), { let mut x = String::from("foo"); x.push_str("bar"); x })
+pub trait Append<Segment: ?Sized>: Sized
+where
+    Segment: ToOwned<Owned = Self>,
+    Self: Borrow<Segment>,
+{
+    fn append(self: Self, s: impl AsRef<Segment>) -> Self;
+}
+
+/// Concatenate `s` to the end of `self`.
+impl Append<str> for String {
+    fn append(mut self: String, s: impl AsRef<str>) -> String {
+        self.push_str(s.as_ref());
+        self
+    }
+}
+
+/// Concatenate `s` to the end of `self`.
+impl Append<OsStr> for OsString {
+    fn append(mut self: OsString, s: impl AsRef<OsStr>) -> OsString {
+        self.push(s);
+        self
+    }
+}
+
+/// Add `s` to the end of `self`, as a new component.
+impl Append<Path> for PathBuf {
+    fn append(mut self: PathBuf, s: impl AsRef<Path>) -> PathBuf {
+        self.push(s);
+        self
+    }
+}
+
+/// Add `ext` to `file` just before the extension.
+/// Example:
+/// assert_eq!(add_pre_ext(&PathBuf::from("foo.bar"), "baz"), PathBuf::from("foo.baz.bar"))
+pub fn add_pre_ext(file: &Path, ext: impl AsRef<OsStr>) -> PathBuf {
+    assert!(file.is_file());
+
+    let new_ext = match file.extension() {
+        None => OsString::from(ext.as_ref()),
+        Some(old_ext) => OsString::from(ext.as_ref()).append(".").append(old_ext),
+    };
+    let mut new_file = PathBuf::from(&file);
+    new_file.set_extension(&new_ext);
+    new_file
+}


### PR DESCRIPTION
Rewrite of cargo-verify in rust.
All the features were copied from the python script, but not very well tested.
Some of the command line arguments were changed, see --help.
