### PR TITLE
New cargo-verify fixes

### DIFF
--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -26,8 +26,11 @@ pub fn check_install() -> bool {
 
 /// Run Klee and replay
 pub fn verify(opt: &Opt, name: &str, entry: &str, bcfile: &Path) -> CVResult<Status> {
-    let out_dir = opt.cargo_toml.with_file_name("kleeout").append(name);
+    // KLEE output files are put in kleeout directory with filename `name`
+    let klee_dir = opt.cargo_toml.with_file_name("kleeout");
+    fs::create_dir_all(klee_dir.clone())?;
 
+    let out_dir = klee_dir.append(name);
     // Ignoring result. We don't care if it fails because the path doesn't
     // exist.
     fs::remove_dir_all(&out_dir).unwrap_or_default();

--- a/cargo-verify/src/main.rs
+++ b/cargo-verify/src/main.rs
@@ -462,7 +462,7 @@ fn build(opt: &Opt, package: &str, target: &str) -> CVResult<PathBuf> {
 /// Return the environment variables needed for building.  Each item in the
 /// vector is a pair `(a, b)` where `a` is the variable name and `b` is its
 /// value.
-fn get_build_envs(opt: &Opt) -> CVResult<Vec<(String, String)>> {
+fn get_build_envs(_opt: &Opt) -> CVResult<Vec<(String, String)>> {
     let mut rustflags = vec![
         "-Clto", // Generate linked bitcode for entire crate
         "-Cembed-bitcode=yes",
@@ -483,11 +483,6 @@ fn get_build_envs(opt: &Opt) -> CVResult<Vec<(String, String)>> {
         "-Clink-arg=-fuse-ld=lld",
     ]
     .join(" ");
-
-    if opt.backend != Backend::Seahorn {
-        // Avoid generating SSE instructions
-        rustflags.push_str(" -Copt-level=1");
-    }
 
     match std::env::var_os("RUSTFLAGS") {
         Some(env) => {

--- a/cargo-verify/src/run_tools.rs
+++ b/cargo-verify/src/run_tools.rs
@@ -204,6 +204,9 @@ pub fn list_tests(opt: &Opt, target: &str) -> CVResult<Vec<String>> {
         cmd.arg("--features").arg(opt.features.join(","));
     }
 
+    // List the types of test we do want - to (implicitly) exclude doc tests.
+    cmd.arg("--lib").arg("--bins");
+
     cmd.arg(format!("--target={}", target))
         .args(vec!["-v"; opt.verbose])
         .envs(get_build_envs(&opt)?)


### PR DESCRIPTION
Two minor fixes:

- Don't optimize (even if using KLEE). It slows the build process and doesn't seem to help verification step. 
- 'cargo test -- --list' started failing complaining about not being able to build doctests 
  because we did not install the rustdoc component for our stage1 compiler.
  Prevent this error by not trying to verify doctests.