### PR TITLE
KLEE-related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 Cargo.lock
 target/
-compatibility-test/kleeout-*/
-verification-annotations/kleeout-*/
+kleeout/
 .*un~
 .*swp

--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -26,8 +26,11 @@ pub fn check_install() -> bool {
 
 /// Run Klee and replay
 pub fn verify(opt: &Opt, name: &str, entry: &str, bcfile: &Path) -> CVResult<Status> {
-    let out_dir = opt.cargo_toml.with_file_name("kleeout").append(name);
+    // KLEE output files are put in kleeout directory with filename `name`
+    let klee_dir = opt.cargo_toml.with_file_name("kleeout");
+    fs::create_dir_all(&klee_dir)?;
 
+    let out_dir = klee_dir.append(name);
     // Ignoring result. We don't care if it fails because the path doesn't
     // exist.
     fs::remove_dir_all(&out_dir).unwrap_or_default();

--- a/cargo-verify/src/main.rs
+++ b/cargo-verify/src/main.rs
@@ -462,7 +462,7 @@ fn build(opt: &Opt, package: &str, target: &str) -> CVResult<PathBuf> {
 /// Return the environment variables needed for building.  Each item in the
 /// vector is a pair `(a, b)` where `a` is the variable name and `b` is its
 /// value.
-fn get_build_envs(opt: &Opt) -> CVResult<Vec<(String, String)>> {
+fn get_build_envs(_opt: &Opt) -> CVResult<Vec<(String, String)>> {
     let mut rustflags = vec![
         "-Clto", // Generate linked bitcode for entire crate
         "-Cembed-bitcode=yes",
@@ -483,11 +483,6 @@ fn get_build_envs(opt: &Opt) -> CVResult<Vec<(String, String)>> {
         "-Clink-arg=-fuse-ld=lld",
     ]
     .join(" ");
-
-    if opt.backend != Backend::Seahorn {
-        // Avoid generating SSE instructions
-        rustflags.push_str(" -Copt-level=1");
-    }
 
     match std::env::var_os("RUSTFLAGS") {
         Some(env) => {

--- a/cargo-verify/src/run_tools.rs
+++ b/cargo-verify/src/run_tools.rs
@@ -204,6 +204,13 @@ pub fn list_tests(opt: &Opt, target: &str) -> CVResult<Vec<String>> {
         cmd.arg("--features").arg(opt.features.join(","));
     }
 
+    // Surprisingly, the effect of the following line is to prevent
+    // consideration of doc tests from the list of tests.
+    // We ignore doc tests because installing rustdoc to enable this
+    // causes additional build problems and because we don't currently
+    // expect doc tests to be based on property-based testing.
+    cmd.arg("--all-targets");
+
     cmd.arg(format!("--target={}", target))
         .args(vec!["-v"; opt.verbose])
         .envs(get_build_envs(&opt)?)

--- a/docker/init
+++ b/docker/init
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+set -e
+
+# Build libraries
+make -C runtime TGT=klee
+make -C runtime TGT=seahorn
+
+# Build tools
+mkdir -p ${USER_HOME}/bin
+cargo install --root=${USER_HOME} --path=${RVT_DIR}/rvt-patch-llvm
+cargo +nightly install --root=${USER_HOME} --path=${RVT_DIR}/cargo-verify

--- a/docker/rvt/Dockerfile
+++ b/docker/rvt/Dockerfile
@@ -62,4 +62,6 @@ COPY --chown=${USER_UID}:${USER_GID} ./cargo-verify ${USER_HOME}/cargo-verify
 RUN cargo +nightly install --root=${USER_HOME} --path=${USER_HOME}/cargo-verify
 
 # Create a bashrc file
-RUN echo "export PATH=\"${PATH}\"" >> ${USER_HOME}/.bashrc
+RUN echo "export PATH=\"${PATH}\"" >> ${USER_HOME}/.bashrc \\
+  && echo "ulimit -c0" >> ${USER_HOME}/.bashrc
+

--- a/runtime/.gitignore
+++ b/runtime/.gitignore
@@ -1,2 +1,2 @@
 build_*
-librvt-*.a
+rvt-*.bc


### PR DESCRIPTION
These changes get scripts/regression-test to pass.
(This script tests KLEE - next step will be extending the script to also check SeaHorn.)

- Don't optimize even when using KLEE (turns out it was not always beneficial)
- Prevent 'cargo verify --tests' from complaining that rustdoc is not installed.
  (Installing rustdoc does not solve this problem, getting 'cargo test -- --tests' not to consider doc tests is the fix)
- Fix minor problem involving creation of kleeout directory
- Update gitignore rules to handle kleeout directory
- In docker, ensure that dumping core files is off by default.
   (I don't know when I ever found core files useful)
- Add 'docker/init' script that rebuilds all the tools/libraries that we depend on.
   (This doesn't get used while building docker images - I haven't figured that out yet. But it is really useful to use within a running docker container)