### PR TITLE
Add `--script` for generating a script

### DIFF
--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -178,7 +178,7 @@ fn run(
         .arg(bcfile)
         .args(&opt.args)
         // .current_dir(&opt.crate_dir);
-        .latin1_output_info_ignore_exit()?;
+        .latin1_output_info_ignore_exit(&opt)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])
@@ -315,7 +315,7 @@ fn replay_klee(opt: &Opt, name: &str, ktest: &Path) -> CVResult<()> {
 
     // Note that we do not treat this as an error, because
     // the interesting case for replay is when KLEE had found an error.
-    let (stdout, stderr, _success) = cmd.output_info_ignore_exit()?;
+    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt)?;
 
     for line in stdout.lines().chain(stderr.lines()) {
         println!("{}", line);

--- a/cargo-verify/src/proptest.rs
+++ b/cargo-verify/src/proptest.rs
@@ -41,7 +41,7 @@ pub fn run(opt: &Opt) -> CVResult<Status> {
         cmd.arg("--").args(&opt.args);
     }
 
-    match cmd.output_info_ignore_exit() {
+    match cmd.output_info_ignore_exit(&opt) {
         Err(e) => {
             warn!("Proptest failed '{:?}'", e);
             Ok(Status::Error)

--- a/cargo-verify/src/seahorn.rs
+++ b/cargo-verify/src/seahorn.rs
@@ -112,7 +112,7 @@ fn run(opt: &Opt, name: &str, entry: &str, bcfile: &Path, out_dir: &Path) -> CVR
         .arg(&bcfile);
     // .args(&opt.args)
 
-    let (stdout, stderr, _) = cmd.output_info_ignore_exit()?;
+    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])


### PR DESCRIPTION
Add two new fields to `Opt`, `script_arg` to hold the user option (value from CL), and `script` which is a `Mutex` protecting a `File` so we can write to the script from concurrent jobs.

The new function `add_to_script` does the actual writing to the script, everytime cargo-verify executes a command.
