### PR TITLE
KLEE extensions for path merging and concretization

### DIFF
--- a/demos/bottlenecks/merging/Cargo.toml
+++ b/demos/bottlenecks/merging/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "merging"
+version = "0.1.0"
+authors = ["Alastair Reid <adreid@google.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+verification-annotations = { path="/home/rust-verification-tools/verification-annotations" }
+
+[features]
+verifier-klee = ["verification-annotations/verifier-klee"]
+verifier-crux = ["verification-annotations/verifier-crux"]
+verifier-seahorn = ["verification-annotations/verifier-seahorn"]

--- a/demos/bottlenecks/merging/src/main.rs
+++ b/demos/bottlenecks/merging/src/main.rs
@@ -1,0 +1,85 @@
+/// Test the impact of path merging.
+///
+/// This is a scaling test to explore path explosions
+/// using the canonical symbolic execution example of
+/// a loop with multiple branches in it which results
+/// in 2^N paths unless merging is used.
+///
+/// Running this test on KLEE with
+///
+///     cargo verify --backend=klee --tests -vv --backend-flags=--use-merge |& grep 'generated tests'
+///
+/// should result in
+///
+///       test_original: {"generated tests": 1024, "total instructions": 709566, "completed paths": 4093}
+///       test_merged: {"generated tests": 1, "completed paths": 41, "total instructions": 11852}
+///
+/// Indicating that the original version suffers from a path explosion and generates
+/// more tests, executes more instructions and explores more paths than the merged version.
+
+use verification_annotations as verifier;
+
+fn main() {
+    println!("Hello, world!");
+}
+
+const N: usize = 10;
+
+/// Test the impact of not using path merging.
+///
+/// The critical part of this example is the second loop
+/// that contains multiple branches where the branches depend
+/// on symbolic expressions.
+///
+/// On a classic symbolic execution tool, this will result in
+/// 2^N paths.
+#[test]
+fn test_original() {
+    // An array
+    let mut a = [0u32; N];
+
+    // Set each element of array to a symbolic value
+    for i in &mut a {
+        *i = verifier::AbstractValue::abstract_value();
+    }
+
+    // A loop containing two branches - this will cause a performance problem
+    // for conventional symbolic execution.
+    for x in &a {
+        verifier::assume((5..10).contains(x) || (15..20).contains(x))
+    }
+
+    // A true assertion about an arbitrary element of the array
+    verifier::assert!(a[3] < 20);
+}
+
+/// Test the impact of using path merging.
+///
+/// This test reduces the number of paths and instructions executed by merging
+/// all the paths forked inside the loop.
+///
+/// There should be just one path when verified using KLEE with --use-merge
+#[test]
+
+/// The test depends on KLEE-specific features
+#[cfg(feature = "verifier-klee")]
+fn test_merged() {
+    // An array
+    let mut a = [0u32; N];
+
+    // Set each element of array to a symbolic value
+    for i in 0..a.len() {
+        a[i] = verifier::AbstractValue::abstract_value();
+    }
+
+    // A loop containing two branches - this will cause a performance problem
+    // for conventional symbolic execution.
+    for x in a.iter() {
+        verifier::coherent!{{
+            verifier::assume((5..10).contains(x) || (15..20).contains(x))
+        }}
+    }
+
+    // A true assertion about an arbitrary element of the array
+    verifier::assert!(a[3] < 20);
+}

--- a/scripts/regression-test
+++ b/scripts/regression-test
@@ -10,5 +10,6 @@ cargo-verify ${FLAGS} --tests --manifest-path=compatibility-test/Cargo.toml
 cargo-verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/bornholt2018-1/Cargo.toml
 cargo-verify ${FLAGS} --tests --manifest-path=demos/simple/ffi/Cargo.toml
 cargo-verify ${FLAGS} -v -v -v --manifest-path=demos/simple/argv/Cargo.toml -- foo foo
+cargo verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/merging/Cargo.toml --backend-flags=--use-merge
 
 echo Regression test successful

--- a/verification-annotations/src/klee.rs
+++ b/verification-annotations/src/klee.rs
@@ -226,6 +226,22 @@ macro_rules! coherent {
     };
 }
 
+/// Exhaustively enumerate all possible concrete values for `x`.
+///
+/// If there are a finite number of possible values for `x`,
+/// this terminates because get_concrete_value terminates this path
+/// if there are no further solutions.
+pub fn concretize<T>(x: T) -> T
+    where T: VerifierNonDet + Eq + Copy
+{
+    loop {
+        let s = T::get_concrete_value(x);
+        if s == x {
+            return s;
+        }
+    }
+}
+
 /// Reject the current execution with a verification failure
 /// and an error message.
 pub fn report_error(message: &str) -> ! {

--- a/verification-annotations/src/klee.rs
+++ b/verification-annotations/src/klee.rs
@@ -242,6 +242,23 @@ pub fn concretize<T>(x: T) -> T
     }
 }
 
+/// Generate `samples` paths each of which explores a single, distinct
+/// concrete value for `x` which is expected to be symbolic.
+///
+/// In most cases, this results in an incomplete exploration because there may
+/// be more possible solutions than we explore.
+pub fn sample<T>(samples: usize, x: T) -> T
+    where T: VerifierNonDet + Eq + Copy
+{
+    for _i in 0..samples-1 {
+        let s = T::get_concrete_value(x);
+        if s == x {
+            return s;
+        }
+    }
+    T::get_concrete_value(x)
+}
+
 /// Reject the current execution with a verification failure
 /// and an error message.
 pub fn report_error(message: &str) -> ! {

--- a/verification-annotations/src/tests.rs
+++ b/verification-annotations/src/tests.rs
@@ -85,6 +85,29 @@ fn t5() {
     verifier::assert_ne!(a, a+1);
 }
 
+// KLEE-only test of get_concrete_value and is_symbolic
+#[cfg(feature = "verifier-klee")]
+#[test]
+fn concrete1() {
+    let a : u32 = verifier::AbstractValue::abstract_value();
+    verifier::assume(a <= 100); // avoid overflow
+    verifier::assert!(verifier::VerifierNonDet::is_symbolic(a));
+
+    let b = verifier::VerifierNonDet::get_concrete_value(a);
+    verifier::assert!(verifier::VerifierNonDet::is_symbolic(a));
+    verifier::assert!(!verifier::VerifierNonDet::is_symbolic(b));
+    verifier::assert!(b <= 100);
+
+    // There is no expectation that each call to get_concrete_value
+    // will produce a different result and, on KLEE, it can
+    // produce the same result unless you add assumptions/branches
+    // to avoid repetition.
+    // This test is commented out because we don't want to insist
+    // on one behavior or another.
+    // let c = verifier::VerifierNonDet::get_concrete_value(a);
+    // verifier::assert_eq!(b, c);
+}
+
 ////////////////////////////////////////////////////////////////
 // End
 ////////////////////////////////////////////////////////////////

--- a/verification-annotations/src/tests.rs
+++ b/verification-annotations/src/tests.rs
@@ -108,6 +108,20 @@ fn concrete1() {
     // verifier::assert_eq!(b, c);
 }
 
+// KLEE-only test of concretize
+#[cfg(feature = "verifier-klee")]
+#[test]
+fn concrete2() {
+    let a : u32 = verifier::AbstractValue::abstract_value();
+    verifier::assume(a <= 10); // limit number of distinct solutions
+    verifier::assert!(verifier::VerifierNonDet::is_symbolic(a));
+
+    let b = verifier::concretize(a);
+    verifier::assert!(verifier::VerifierNonDet::is_symbolic(a));
+    verifier::assert!(!verifier::VerifierNonDet::is_symbolic(b));
+    verifier::assert!(b <= 10);
+}
+
 ////////////////////////////////////////////////////////////////
 // End
 ////////////////////////////////////////////////////////////////

--- a/verification-annotations/src/tests.rs
+++ b/verification-annotations/src/tests.rs
@@ -122,6 +122,20 @@ fn concrete2() {
     verifier::assert!(b <= 10);
 }
 
+// KLEE-only test of sample
+#[cfg(feature = "verifier-klee")]
+#[test]
+fn concrete3() {
+    let a : u32 = verifier::AbstractValue::abstract_value();
+    verifier::assume(a <= 1_000_000_000); // allow a huge number of solutions
+    verifier::assert!(verifier::VerifierNonDet::is_symbolic(a));
+
+    let b = verifier::sample(10, a); // consider only 10 of the possible solutions for a
+    verifier::assert!(verifier::VerifierNonDet::is_symbolic(a));
+    verifier::assert!(!verifier::VerifierNonDet::is_symbolic(b));
+    verifier::assert!(b <= 1_000_000_000);
+}
+
 ////////////////////////////////////////////////////////////////
 // End
 ////////////////////////////////////////////////////////////////

--- a/verification-annotations/src/traits.rs
+++ b/verification-annotations/src/traits.rs
@@ -22,6 +22,27 @@ use crate::assume;
 /// This is intended to be compatible with SMACK
 pub trait VerifierNonDet {
     fn verifier_nondet(self) -> Self;
+
+    #[cfg(feature = "verifier-klee")]
+    /// Obtain a concrete value satisfying the constraints
+    /// currently in force for the expression.
+	///
+	/// Not guaranteed to produce different (or the same) value
+	/// if called repeatedly.
+	/// (Use assumptions or if-statements to produce different results
+	/// each time.)
+    ///
+    /// This function may not be implementable with other
+    /// verifiers so it should be used with caution.
+    fn get_concrete_value(x: Self) -> Self;
+
+    #[cfg(feature = "verifier-klee")]
+	/// Test whether a value is concrete or symbolic
+	///
+	/// Values are guaranteed to be concrete if they are derived
+	/// from concrete values, literal constants or
+	/// calls to `get_concrete_value`.
+	fn is_symbolic(x: Self) -> bool;
 }
 
 pub trait AbstractValue : Sized {


### PR DESCRIPTION
Adds the following functions

- `concretize!` to merge paths within a block
- `is_symbolic(x)` to test if a value x is symbolic or concrete
- `get_concrete_value(x)` to solve the current constraints on a value x and return a concrete value (this is most useful on symbolic values :-))
- `concretize(x)` to exhaustively solve the current constraints on a value x
  - forks separate paths for each resulting concrete value
  - since concretize is exhaustive, this may result in far more paths than you want
- `sample(N, x)` to solve the current constraints on a value up to N times
  - forks up to N separate paths for each resulting concrete value
  - since sample is not exhaustive, sample does not explore all possible behaviours of the program

At the moment, these extensions are only supported by the KLEE backend.
It may not be possible to implement these extensions for all backends.