### PR TITLE
cargo-verify: tweak verbosity

### DIFF
--- a/cargo-verify/Cargo.toml
+++ b/cargo-verify/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ansi_term = "0.12"
 cargo_metadata = "0.12.3"
 glob = "0.3.0"
 lazy_static = "1.4.0"

--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -178,7 +178,7 @@ fn run(
         .arg(bcfile)
         .args(&opt.args)
         // .current_dir(&opt.crate_dir);
-        .latin1_output_info_ignore_exit(&opt, 3)?;
+        .latin1_output_info_ignore_exit(&opt, Verbosity::Major)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])
@@ -319,7 +319,7 @@ fn replay_klee(opt: &Opt, name: &str, ktest: &Path) -> CVResult<()> {
 
     // Note that we do not treat this as an error, because
     // the interesting case for replay is when KLEE had found an error.
-    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt, 3)?;
+    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt, Verbosity::Major)?;
 
     for line in stdout.lines().chain(stderr.lines()) {
         println!("{}", line);

--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -178,7 +178,7 @@ fn run(
         .arg(bcfile)
         .args(&opt.args)
         // .current_dir(&opt.crate_dir);
-        .latin1_output_info_ignore_exit(&opt)?;
+        .latin1_output_info_ignore_exit(&opt, 2)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])
@@ -319,7 +319,7 @@ fn replay_klee(opt: &Opt, name: &str, ktest: &Path) -> CVResult<()> {
 
     // Note that we do not treat this as an error, because
     // the interesting case for replay is when KLEE had found an error.
-    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt)?;
+    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt, 2)?;
 
     for line in stdout.lines().chain(stderr.lines()) {
         println!("{}", line);

--- a/cargo-verify/src/klee.rs
+++ b/cargo-verify/src/klee.rs
@@ -178,7 +178,7 @@ fn run(
         .arg(bcfile)
         .args(&opt.args)
         // .current_dir(&opt.crate_dir);
-        .latin1_output_info_ignore_exit(&opt, 2)?;
+        .latin1_output_info_ignore_exit(&opt, 3)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])
@@ -319,7 +319,7 @@ fn replay_klee(opt: &Opt, name: &str, ktest: &Path) -> CVResult<()> {
 
     // Note that we do not treat this as an error, because
     // the interesting case for replay is when KLEE had found an error.
-    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt, 2)?;
+    let (stdout, stderr, _success) = cmd.output_info_ignore_exit(&opt, 3)?;
 
     for line in stdout.lines().chain(stderr.lines()) {
         println!("{}", line);

--- a/cargo-verify/src/main.rs
+++ b/cargo-verify/src/main.rs
@@ -474,7 +474,7 @@ fn build(opt: &Opt, package: &str, target: &str) -> CVResult<PathBuf> {
         .arg(runtime)
         .arg(&bc_file)
         .args(&c_files)
-        .output_info(&opt)?;
+        .output_info(&opt, 3)?;
     bc_file = new_bc_file;
 
     if opt.backend == Backend::Seahorn {
@@ -572,7 +572,7 @@ fn compile(opt: &Opt, package: &str, target: &str) -> CVResult<(PathBuf, Vec<Pat
     cmd.arg(format!("--target={}", target))
         .args(vec!["-v"; opt.verbose])
         .envs(get_build_envs(&opt)?)
-        .output_info(&opt)?;
+        .output_info(&opt, 0)?;
     // .env("PATH", ...)
 
     // Find the target directory
@@ -613,7 +613,7 @@ fn compile(opt: &Opt, package: &str, target: &str) -> CVResult<(PathBuf, Vec<Pat
             if opt.tests || !opt.test.is_empty() {
                 Err("  FAILED: Use --tests with library crates")?
             } else {
-                Err(format!("  FAILED: Test {} compilation error", &package))?
+                Err(format!("  FAILED: Test {} unable to find the right bitcode file - should you have used --tests?", &package))?
             }
         }
         _ => {
@@ -664,7 +664,7 @@ fn patch_llvm(opt: &Opt, options: &[&str], bcfile: &Path, new_bcfile: &Path) -> 
         .arg(new_bcfile)
         .args(options)
         .args(vec!["-v"; opt.verbose])
-        .output_info(&opt)?;
+        .output_info(&opt, 3)?;
     Ok(())
 }
 
@@ -688,7 +688,7 @@ fn mangle_functions(
     let (stdout, _) = Command::new("llvm-nm")
         .arg("--defined-only")
         .arg(bcfile)
-        .output_info(&opt)?;
+        .output_info(&opt, 4)?;
 
     let rs: Vec<(String, String)> = stdout
         .lines()

--- a/cargo-verify/src/main.rs
+++ b/cargo-verify/src/main.rs
@@ -502,7 +502,7 @@ fn build(opt: &Opt, package: &str, target: &str) -> CVResult<PathBuf> {
         .arg(runtime)
         .arg(&bc_file)
         .args(&c_files)
-        .output_info(&opt, 3)?;
+        .latin1_output_info(&opt, 3)?;
     bc_file = new_bc_file;
 
     if opt.backend == Backend::Seahorn {

--- a/cargo-verify/src/proptest.rs
+++ b/cargo-verify/src/proptest.rs
@@ -41,7 +41,7 @@ pub fn run(opt: &Opt) -> CVResult<Status> {
         cmd.arg("--").args(&opt.args);
     }
 
-    match cmd.output_info_ignore_exit(&opt, 2) {
+    match cmd.output_info_ignore_exit(&opt, 3) {
         Err(e) => {
             warn!("Proptest failed '{:?}'", e);
             Ok(Status::Error)

--- a/cargo-verify/src/proptest.rs
+++ b/cargo-verify/src/proptest.rs
@@ -41,7 +41,7 @@ pub fn run(opt: &Opt) -> CVResult<Status> {
         cmd.arg("--").args(&opt.args);
     }
 
-    match cmd.output_info_ignore_exit(&opt, 3) {
+    match cmd.output_info_ignore_exit(&opt, Verbosity::Major) {
         Err(e) => {
             warn!("Proptest failed '{:?}'", e);
             Ok(Status::Error)

--- a/cargo-verify/src/proptest.rs
+++ b/cargo-verify/src/proptest.rs
@@ -41,7 +41,7 @@ pub fn run(opt: &Opt) -> CVResult<Status> {
         cmd.arg("--").args(&opt.args);
     }
 
-    match cmd.output_info_ignore_exit(&opt) {
+    match cmd.output_info_ignore_exit(&opt, 2) {
         Err(e) => {
             warn!("Proptest failed '{:?}'", e);
             Ok(Status::Error)

--- a/cargo-verify/src/run_tools.rs
+++ b/cargo-verify/src/run_tools.rs
@@ -6,28 +6,28 @@ use crate::*;
 
 /// Trait for wrapping `std::process::Command::output()` with logging.
 pub trait OutputInfo {
-    fn output_info(&mut self, opt: &Opt, lvl: usize) -> CVResult<(String, String)> {
+    fn output_info(&mut self, opt: &Opt, lvl: Verbosity) -> CVResult<(String, String)> {
         self.output_info_helper(&opt, lvl, |v| String::from(from_utf8(v).expect("not UTF-8")), false)
             .map(|(stdout, stderr, _)| (stdout, stderr))
     }
 
-    fn latin1_output_info(&mut self, opt: &Opt, lvl: usize) -> CVResult<(String, String)> {
+    fn latin1_output_info(&mut self, opt: &Opt, lvl: Verbosity) -> CVResult<(String, String)> {
         self.output_info_helper(&opt, lvl, utils::from_latin1, false)
             .map(|(stdout, stderr, _)| (stdout, stderr))
     }
 
-    fn output_info_ignore_exit(&mut self, opt: &Opt, lvl: usize) -> CVResult<(String, String, bool)> {
+    fn output_info_ignore_exit(&mut self, opt: &Opt, lvl: Verbosity) -> CVResult<(String, String, bool)> {
         self.output_info_helper(&opt, lvl, |v| String::from(from_utf8(v).expect("not UTF-8")), true)
     }
 
-    fn latin1_output_info_ignore_exit(&mut self, opt: &Opt, lvl: usize) -> CVResult<(String, String, bool)> {
+    fn latin1_output_info_ignore_exit(&mut self, opt: &Opt, lvl: Verbosity) -> CVResult<(String, String, bool)> {
         self.output_info_helper(&opt, lvl, utils::from_latin1, true)
     }
 
     fn output_info_helper(
         &mut self,
         opt: &Opt,
-        lvl: usize,
+        lvl: Verbosity,
         trans: impl Fn(&[u8]) -> String,
         ignore_exit: bool,
     ) -> CVResult<(String, String, bool)>;
@@ -37,7 +37,7 @@ impl OutputInfo for Command {
     fn output_info_helper(
         &mut self,
         opt: &Opt,
-        lvl: usize,
+        lvl: Verbosity,
         trans: impl Fn(&[u8]) -> String,
         ignore_exit: bool,
     ) -> CVResult<(String, String, bool)> {
@@ -163,7 +163,7 @@ fn add_to_script(cmd: &Command, opt: &Opt) -> CVResult<()> {
 }
 
 /// Print each line of `Lines` using `info!`, prefixed with `prefix`.
-pub fn info_lines(opt: &Opt, lvl: usize, prefix: &str, lines: Lines) {
+pub fn info_lines(opt: &Opt, lvl: Verbosity, prefix: &str, lines: Lines) {
     for l in lines {
         info_at!(&opt, lvl, "{}{}", prefix, l);
     }
@@ -171,12 +171,12 @@ pub fn info_lines(opt: &Opt, lvl: usize, prefix: &str, lines: Lines) {
 
 /// Run `cargo clean`.
 pub fn clean(opt: &Opt) {
-    info_at!(&opt, 2, "Running `cargo clean`");
+    info_at!(&opt, Verbosity::Informative, "Running `cargo clean`");
     Command::new("cargo")
         .arg("clean")
         .arg("--manifest-path")
         .arg(&opt.cargo_toml)
-        .output_info_ignore_exit(&opt, 5)
+        .output_info_ignore_exit(&opt, Verbosity::Major)
         .ok(); // Discarding the error on purpose.
 }
 
@@ -227,7 +227,7 @@ pub fn get_default_host(opt: &Opt) -> CVResult<String> {
     }
 
     Ok(cmd
-        .output_info(&opt, 5)?
+        .output_info(&opt, Verbosity::Trivial)?
         .0
         .lines()
         .find_map(|l| l.strip_prefix("Default host:").and_then(|l| Some(l.trim())))
@@ -239,7 +239,7 @@ pub fn get_default_host(opt: &Opt) -> CVResult<String> {
 pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
     info_at!(
         &opt,
-        5,
+        Verbosity::Trivial,
         "    Counting symbols {:?} in {}",
         fs,
         bcfile.to_string_lossy()
@@ -247,7 +247,7 @@ pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
 
     let mut cmd = Command::new("llvm-nm");
     cmd.arg("--defined-only").arg(bcfile);
-    let (stdout, _) = cmd.output_info(&opt, 5)?;
+    let (stdout, _) = cmd.output_info(&opt, Verbosity::Trivial)?;
 
     let count = stdout
         .lines()
@@ -255,7 +255,7 @@ pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
         .filter(|l| l.len() == 3 && l[1] == "T" && fs.iter().any(|f| f == &l[2]))
         .count();
 
-    info_at!(&opt, 5, "    Found {} functions", count);
+    info_at!(&opt, Verbosity::Trivial, "    Found {} functions", count);
     Ok(count)
 }
 
@@ -289,7 +289,7 @@ pub fn list_tests(opt: &Opt, target: &str) -> CVResult<Vec<String>> {
 
     // TODO: Python ignores bad exit codes
     let tests = cmd
-        .output_info(&opt, 4)?
+        .output_info(&opt, Verbosity::Minor)?
         .0
         .lines()
         .filter_map(|l| {

--- a/cargo-verify/src/run_tools.rs
+++ b/cargo-verify/src/run_tools.rs
@@ -171,12 +171,12 @@ pub fn info_lines(opt: &Opt, lvl: usize, prefix: &str, lines: Lines) {
 
 /// Run `cargo clean`.
 pub fn clean(opt: &Opt) {
-    info_at!(&opt, 1, "Running `cargo clean`");
+    info_at!(&opt, 2, "Running `cargo clean`");
     Command::new("cargo")
         .arg("clean")
         .arg("--manifest-path")
         .arg(&opt.cargo_toml)
-        .output_info_ignore_exit(&opt, 4)
+        .output_info_ignore_exit(&opt, 5)
         .ok(); // Discarding the error on purpose.
 }
 
@@ -227,7 +227,7 @@ pub fn get_default_host(opt: &Opt) -> CVResult<String> {
     }
 
     Ok(cmd
-        .output_info(&opt, 4)?
+        .output_info(&opt, 5)?
         .0
         .lines()
         .find_map(|l| l.strip_prefix("Default host:").and_then(|l| Some(l.trim())))
@@ -239,7 +239,7 @@ pub fn get_default_host(opt: &Opt) -> CVResult<String> {
 pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
     info_at!(
         &opt,
-        4,
+        5,
         "    Counting symbols {:?} in {}",
         fs,
         bcfile.to_string_lossy()
@@ -247,7 +247,7 @@ pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
 
     let mut cmd = Command::new("llvm-nm");
     cmd.arg("--defined-only").arg(bcfile);
-    let (stdout, _) = cmd.output_info(&opt, 4)?;
+    let (stdout, _) = cmd.output_info(&opt, 5)?;
 
     let count = stdout
         .lines()
@@ -255,7 +255,7 @@ pub fn count_symbols(opt: &Opt, bcfile: &Path, fs: &[&str]) -> CVResult<usize> {
         .filter(|l| l.len() == 3 && l[1] == "T" && fs.iter().any(|f| f == &l[2]))
         .count();
 
-    info_at!(&opt, 4, "    Found {} functions", count);
+    info_at!(&opt, 5, "    Found {} functions", count);
     Ok(count)
 }
 
@@ -289,7 +289,7 @@ pub fn list_tests(opt: &Opt, target: &str) -> CVResult<Vec<String>> {
 
     // TODO: Python ignores bad exit codes
     let tests = cmd
-        .output_info(&opt, 3)?
+        .output_info(&opt, 4)?
         .0
         .lines()
         .filter_map(|l| {

--- a/cargo-verify/src/seahorn.rs
+++ b/cargo-verify/src/seahorn.rs
@@ -112,7 +112,7 @@ fn run(opt: &Opt, name: &str, entry: &str, bcfile: &Path, out_dir: &Path) -> CVR
         .arg(&bcfile);
     // .args(&opt.args)
 
-    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt, 2)?;
+    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt, 3)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])

--- a/cargo-verify/src/seahorn.rs
+++ b/cargo-verify/src/seahorn.rs
@@ -112,7 +112,7 @@ fn run(opt: &Opt, name: &str, entry: &str, bcfile: &Path, out_dir: &Path) -> CVR
         .arg(&bcfile);
     // .args(&opt.args)
 
-    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt, 3)?;
+    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt, Verbosity::Major)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])

--- a/cargo-verify/src/seahorn.rs
+++ b/cargo-verify/src/seahorn.rs
@@ -112,7 +112,7 @@ fn run(opt: &Opt, name: &str, entry: &str, bcfile: &Path, out_dir: &Path) -> CVR
         .arg(&bcfile);
     // .args(&opt.args)
 
-    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt)?;
+    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt, 2)?;
 
     // We scan stderr for:
     // 1. Indications of the expected output (eg from #[should_panic])

--- a/cargo-verify/src/utils.rs
+++ b/cargo-verify/src/utils.rs
@@ -22,7 +22,7 @@ use std::{
 macro_rules! info_at {
     ($opt:expr, $lvl:expr, $($arg:tt)+) => ({
         let lvl = $lvl;
-        if lvl <= $opt.verbose {
+        if lvl <= $opt.verbosity {
             println!($($arg)+);
         }
     });


### PR DESCRIPTION
This incomplete change causes commands to only print stdout/stderr if their level
is below the current verbosity.

To finish this off, I (Alastair) plan to add -q/--quiet support as well.