### PR TITLE
docker/init: use the right compiler

### DIFF
--- a/docker/init
+++ b/docker/init
@@ -8,6 +8,6 @@ make -C runtime TGT=seahorn
 
 # Build tools
 mkdir -p ${USER_HOME}/bin
-cargo install --root=${USER_HOME} --path=${RVT_DIR}/rust2calltree
-cargo install --root=${USER_HOME} --path=${RVT_DIR}/rvt-patch-llvm
+cargo +nightly install --root=${USER_HOME} --path=${RVT_DIR}/rust2calltree
+cargo +nightly install --root=${USER_HOME} --path=${RVT_DIR}/rvt-patch-llvm
 cargo +nightly install --root=${USER_HOME} --path=${RVT_DIR}/cargo-verify


### PR DESCRIPTION
This avoids problems with our use of an old Rust compiler version for
verification affecting how we build the tools we use to do the verification.

For rust2calltree and rvt-patch-llvm, we do not need nightly but it is the
compiler that we know is installed and somewhat recent.
For cargo-verify, we do need nightly because it depends on experimental
library features.