### PR TITLE
Refactor verification-annotations

### DIFF
--- a/demos/bottlenecks/merging/src/main.rs
+++ b/demos/bottlenecks/merging/src/main.rs
@@ -17,7 +17,7 @@
 /// Indicating that the original version suffers from a path explosion and generates
 /// more tests, executes more instructions and explores more paths than the merged version.
 
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 fn main() {
     println!("Hello, world!");
@@ -40,7 +40,7 @@ fn test_original() {
 
     // Set each element of array to a symbolic value
     for i in &mut a {
-        *i = verifier::AbstractValue::abstract_value();
+        *i = u32::abstract_value();
     }
 
     // A loop containing two branches - this will cause a performance problem
@@ -69,7 +69,7 @@ fn test_merged() {
 
     // Set each element of array to a symbolic value
     for i in 0..a.len() {
-        a[i] = verifier::AbstractValue::abstract_value();
+        a[i] = u32::abstract_value();
     }
 
     // A loop containing two branches - this will cause a performance problem

--- a/demos/bottlenecks/regex/src/main.rs
+++ b/demos/bottlenecks/regex/src/main.rs
@@ -16,7 +16,7 @@
 ///    strings very short to keep execution time reasonable.
 
 use regex::Regex;
-use verification_annotations as verifier;
+use verification_annotations::verifier;
 
 fn main() {
     println!("Hello, world!");

--- a/demos/simple/annotations/src/main.rs
+++ b/demos/simple/annotations/src/main.rs
@@ -1,10 +1,10 @@
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 #[cfg_attr(feature="verifier-crux", crux_test)]
 #[cfg_attr(not(feature="verifier-crux"), test)]
 fn t1() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     if verifier::is_replay() {

--- a/demos/simple/klee/src/main.rs
+++ b/demos/simple/klee/src/main.rs
@@ -1,8 +1,8 @@
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 fn main() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     if verifier::is_replay() {

--- a/demos/simple/seahorn/src/main.rs
+++ b/demos/simple/seahorn/src/main.rs
@@ -1,9 +1,8 @@
-
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 fn main() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     let r = a*b;

--- a/demos/simple/string/Cargo.toml
+++ b/demos/simple/string/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "string"
+version = "0.1.0"
+authors = ["Shaked Flur <sflur@google.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+regex = "1"
+
+[target.'cfg(verify)'.dependencies]
+propverify = { path="/home/rust-verification-tools/propverify" }
+verification-annotations = { path = "/home/rust-verification-tools/verification-annotations" }
+
+[target.'cfg(not(verify))'.dependencies]
+proptest = { version = "*" }
+
+[features]
+verifier-klee = ["propverify/verifier-klee", "verification-annotations/verifier-klee"]
+verifier-crux = ["propverify/verifier-crux"]
+verifier-seahorn = ["propverify/verifier-seahorn"]

--- a/demos/simple/string/src/main.rs
+++ b/demos/simple/string/src/main.rs
@@ -1,0 +1,38 @@
+#[cfg(not(verify))]
+use proptest::prelude::*;
+#[cfg(verify)]
+use propverify::prelude::*;
+
+use regex::Regex;
+
+proptest! {
+    #[test]
+    // Construct an arbitrary (utf8) string from 3 bytes.
+    // Klee can only handle a small number of bytes in this case.
+    fn string(s in prop::string::arbitrary(3)) {
+        let re = Regex::new(r"^a").unwrap();
+        prop_assume!(re.is_match(&s));
+        prop_assert!(s.starts_with('a'));
+    }
+}
+
+proptest! {
+    #[test]
+    // Construct a (utf8) string from 100 bytes, restricted to ascii chars.
+    // Klee can handle much more bytes this way.
+    fn ascii_string(s in prop::string::arbitrary_ascii(100)) {
+        let re = Regex::new(r"^a").unwrap();
+        prop_assume!(re.is_match(&s));
+        prop_assert!(s.starts_with('a'));
+    }
+}
+
+proptest! {
+    #[test]
+    #[should_panic]
+    fn string_add(s1 in prop::string::arbitrary_ascii(200), s2 in prop::string::arbitrary_ascii(200)) {
+        let s = s1 + &s2;
+        let s: String = s.chars().rev().collect();
+        prop_assert!(s.len() == 200);
+    }
+}

--- a/docs/_posts/2020-09-01-using-klee.md
+++ b/docs/_posts/2020-09-01-using-klee.md
@@ -46,11 +46,11 @@ This code is in [demos/simple/klee/src/main.rs] and the shell commands in this
 file are in [demos/simple/klee/verify.sh].
 
 ``` rust
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 fn main() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     if verifier::is_replay() {

--- a/docs/_posts/2020-09-02-using-annotations.md
+++ b/docs/_posts/2020-09-02-using-annotations.md
@@ -112,7 +112,7 @@ values of `a` are not legal. For example, you might create a unicode character
 like this:
 
 ```
-let a : u32 = verifier::AbstractValue::abstract_value();
+let a = u32::abstract_value();
 let b = match std::char::from_u32(a) {
     Some(r) => r,
     None => verifier::reject(),
@@ -146,11 +146,11 @@ This code is in [demos/simple/annotations/src/main.rs] and the shell commands in
 file are in [demos/simple/annotations/verify.sh].
 
 ```
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 fn t1() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     #[cfg(not(crux))]
@@ -291,13 +291,13 @@ As a first variation, let's restore the original error and add a call to
 `expect`:
 
 ```
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 #[test]
 fn main() {
     verifier::expect(Some("assertion failed"));
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     if verifier::is_replay() {
@@ -332,13 +332,13 @@ For example, we might allow larger values for `a` and `b` or we might
 just delete the assumptions.
 
 ```
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 #[test]
 fn t1() {
     // verifier::expect(Some("overflow"));
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000000);
     verifier::assume(1 <= b && b <= 1000000);
     if verifier::is_replay() {

--- a/docs/_posts/2021-04-01-using-seahorn.md
+++ b/docs/_posts/2021-04-01-using-seahorn.md
@@ -39,11 +39,11 @@ This code is in [demos/simple/seahorn/src/main.rs] and the shell commands in thi
 file are in [demos/simple/seahorn/verify.sh].
 
 ``` rust
-use verification_annotations as verifier;
+use verification_annotations::prelude::*;
 
 fn main() {
-    let a : u32 = verifier::AbstractValue::abstract_value();
-    let b : u32 = verifier::AbstractValue::abstract_value();
+    let a = u32::abstract_value();
+    let b = u32::abstract_value();
     verifier::assume(1 <= a && a <= 1000);
     verifier::assume(1 <= b && b <= 1000);
     let r = a*b;

--- a/propverify/src/lib.rs
+++ b/propverify/src/lib.rs
@@ -51,9 +51,12 @@ pub mod prelude {
             pub use crate::strategy::{u128, u16, u32, u64, u8, usize};
             #[cfg(feature = "float")] pub use crate::strategy::{f32, f64};
         }
+
+        pub use crate::strategy::string;
     }
 
-    pub use crate::strategy::verifier;
+    pub use verification_annotations;
+    pub use verification_annotations::verifier;
 
     pub use verifier::assert as prop_assert;
     pub use verifier::assert_eq as prop_assert_eq;

--- a/scripts/regression-test
+++ b/scripts/regression-test
@@ -1,12 +1,14 @@
 #! /usr/bin/env bash
 
 set -e
+set -x
 
-readonly FLAGS="--backend=klee --verbose --clean"
 (cd demos/simple/annotations; ./verify.sh)
 (cd demos/simple/klee; ./verify.sh)
 (cd demos/simple/seahorn; ./verify.sh)
 (cd demos/simple/errors; ./verify.sh)
+
+readonly FLAGS="--backend=klee --verbose --clean"
 cargo-verify ${FLAGS} --tests --manifest-path=verification-annotations/Cargo.toml
 cargo-verify ${FLAGS} --tests --manifest-path=compatibility-test/Cargo.toml
 cargo-verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/bornholt2018-1/Cargo.toml
@@ -14,6 +16,7 @@ cargo-verify ${FLAGS} --tests --manifest-path=demos/simple/ffi/Cargo.toml
 cargo-verify ${FLAGS} -v -v -v --manifest-path=demos/simple/argv/Cargo.toml -- foo foo
 cargo verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/merging/Cargo.toml --backend-flags=--use-merge
 cargo verify ${FLAGS} --tests --manifest-path=demos/bottlenecks/regex/Cargo.toml
+cargo-verify ${FLAGS} --tests --manifest-path=demos/simple/string/Cargo.toml
 
 # Test the --backend-flags and --replace-backend-flags options.
 # Note the use of handlebars and passing args to main (foo foo).

--- a/verification-annotations/src/tests.rs
+++ b/verification-annotations/src/tests.rs
@@ -2,9 +2,9 @@
 // Several variations on a theme to test failing variants
 ////////////////////////////////////////////////////////////////
 
-use crate as verifier;
+use crate::prelude::*;
 
-use crate::assert;
+use crate::verifier::assert;
 
 #[cfg_attr(not(feature = "verifier-crux"), test)]
 #[cfg_attr(feature = "verifier-crux", crux_test)]

--- a/verification-annotations/src/traits.rs
+++ b/verification-annotations/src/traits.rs
@@ -13,7 +13,7 @@
 //
 // For some (limited) amount of compatibility, we implement all three
 
-use crate::assume;
+use crate::verifier::assume;
 
 /// Create a non-deterministic value with the same type as the argument
 ///

--- a/verification-annotations/src/verifier/crux.rs
+++ b/verification-annotations/src/verifier/crux.rs
@@ -98,14 +98,14 @@ macro_rules! assert {
 
 #[macro_export]
 macro_rules! assert_eq {
-    ($left:expr, $right:expr) => { $crate::assert!(($left) == ($right)); };
+    ($left:expr, $right:expr) => { $crate::verifier::assert!(($left) == ($right)); };
     // ($left:expr, $right:expr,) => { ... };
     // ($left:expr, $right:expr, $($arg:tt)+) => { ... };
 }
 
 #[macro_export]
 macro_rules! assert_ne {
-    ($left:expr, $right:expr) => { $crate::assert!(($left) != ($right)); };
+    ($left:expr, $right:expr) => { $crate::verifier::assert!(($left) != ($right)); };
     // ($left:expr, $right:expr,) => { ... };
     // ($left:expr, $right:expr, $($arg:tt)+) => { ... };
 }

--- a/verification-annotations/src/verifier/mod.rs
+++ b/verification-annotations/src/verifier/mod.rs
@@ -1,0 +1,150 @@
+// Copyright 2020 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::default::Default;
+use std::ffi::CString;
+
+// Traits for creating symbolic/abstract values
+#[cfg(feature = "verifier-klee")]
+mod klee;
+#[cfg(feature = "verifier-klee")]
+pub use klee::*;
+
+#[cfg(feature = "verifier-crux")]
+pub extern crate crucible;
+#[cfg(feature = "verifier-crux")]
+mod crux;
+#[cfg(feature = "verifier-crux")]
+pub use crux::*;
+
+#[cfg(feature = "verifier-seahorn")]
+mod seahorn;
+#[cfg(feature = "verifier-seahorn")]
+pub use seahorn::*;
+
+/// Allocate a symbolic vector of bytes
+pub fn verifier_nondet_bytes(n: usize) -> Vec<u8> {
+    let mut v: Vec<u8> = Vec::with_capacity(n);
+    v.resize_with(n, || VerifierNonDet::verifier_nondet(0u8));
+    return v
+}
+
+/// Allocate a symbolic CString
+pub fn verifier_nondet_cstring(size_excluding_null: usize) -> CString {
+    let mut r = verifier_nondet_bytes(size_excluding_null + 1);
+    for i in 0..size_excluding_null {
+        assume(r[i] != 0u8);
+    }
+    r[size_excluding_null] = 0u8;
+    unsafe { CString::from_vec_with_nul_unchecked(r) }
+}
+
+/// Allocate a symbolic ASCII String
+/// (ASCII strings avoid the complexity of UTF-8)
+pub fn verifier_nondet_ascii_string(n: usize) -> String {
+    let r = verifier_nondet_bytes(n);
+    for i in 0..n {
+        assume(r[i] != 0u8);
+        assume(r[i].is_ascii());
+    }
+    match String::from_utf8(r) {
+        Ok(r) => r,
+        Err(_) => reject(),
+    }
+}
+
+impl <T: VerifierNonDet + Default> AbstractValue for T {
+    fn abstract_value() -> Self {
+        Self::verifier_nondet(Self::default())
+    }
+}
+
+impl <T: VerifierNonDet + Default> Symbolic for T {
+    fn symbolic(_desc: &'static str) -> Self {
+        Self::verifier_nondet(Self::default())
+    }
+}
+
+
+// Macros
+
+#[macro_export]
+macro_rules! assert {
+    ($cond:expr,) => { $crate::verifier::assert!($cond) };
+    ($cond:expr) => { $crate::verifier::assert!($cond, "assertion failed: {}", stringify!($cond)) };
+    ($cond:expr, $($arg:tt)+) => {{
+        if ! $cond {
+            let message = format!($($arg)+);
+            eprintln!("VERIFIER: panicked at '{}', {}:{}:{}",
+                      message,
+                      std::file!(), std::line!(), std::column!());
+            $crate::verifier::abort();
+        }
+    }}
+}
+
+#[macro_export]
+macro_rules! assert_eq {
+    ($left:expr, $right:expr) => {{
+        let left = $left;
+        let right = $right;
+        $crate::verifier::assert!(
+            left == right,
+            "assertion failed: `(left == right)` \
+             \n  left: `{:?}`,\n right: `{:?}`",
+            left,
+            right)
+    }};
+    ($left:expr, $right:expr, $fmt:tt $($arg:tt)*) => {{
+        let left = $left;
+        let right = $right;
+        $crate::verifier::assert!(
+            left == right,
+            concat!(
+                "assertion failed: `(left == right)` \
+                 \n  left: `{:?}`, \n right: `{:?}`: ", $fmt),
+            left, right $($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_ne {
+    ($left:expr, $right:expr) => {{
+        let left = $left;
+        let right = $right;
+        $crate::verifier::assert!(
+            left != right,
+            "assertion failed: `(left != right)` \
+             \n  left: `{:?}`,\n right: `{:?}`",
+            left,
+            right)
+    }};
+    ($left:expr, $right:expr, $fmt:tt $($arg:tt)*) => {{
+        let left = $left;
+        let right = $right;
+        $crate::verifier::assert!(
+            left != right,
+            concat!(
+                "assertion failed: `(left != right)` \
+                 \n  left: `{:?}`, \n right: `{:?}`: ", $fmt),
+            left, right $($arg)*);
+    }};
+}
+
+#[macro_export]
+macro_rules! unreachable {
+    () => { $crate::report_error("unreachable assertion was reached"); };
+}
+
+pub use crate::assert;
+pub use crate::assert_eq;
+pub use crate::assert_ne;
+pub use crate::unreachable;
+
+#[cfg(feature = "verifier-klee")]
+pub use crate::coherent;

--- a/verification-annotations/src/verifier/seahorn.rs
+++ b/verification-annotations/src/verifier/seahorn.rs
@@ -10,7 +10,6 @@
 // FFI wrapper for SeaHorn symbolic execution tool
 /////////////////////////////////////////////////////////////////
 
-use std::default::Default;
 use std::convert::TryInto;
 
 pub use crate::traits::*;
@@ -127,88 +126,12 @@ macro_rules! make_nondet_ne_bytes {
 make_nondet_ne_bytes!(u128);
 make_nondet_ne_bytes!(i128);
 
-
 impl VerifierNonDet for bool {
     fn verifier_nondet(self) -> Self {
         let c = u8::verifier_nondet(0u8);
         assume(c == 0 || c == 1);
         c == 1
     }
-}
-
-impl <T: VerifierNonDet + Default> AbstractValue for T {
-    fn abstract_value() -> Self {
-        Self::verifier_nondet(Self::default())
-    }
-}
-
-impl <T: VerifierNonDet + Default> Symbolic for T {
-    fn symbolic(_desc: &'static str) -> Self {
-        Self::verifier_nondet(Self::default())
-    }
-}
-
-#[macro_export]
-macro_rules! assert {
-    ($cond:expr,) => { $crate::assert!($cond) };
-    ($cond:expr) => { $crate::assert!($cond, "assertion failed: {}", stringify!($cond)) };
-    ($cond:expr, $($arg:tt)+) => {{
-        if ! $cond {
-            let message = format!($($arg)+);
-            eprintln!("VERIFIER: panicked at '{}', {}:{}:{}",
-                      message,
-                      std::file!(), std::line!(), std::column!());
-            $crate::abort();
-        }
-    }}
-}
-
-#[macro_export]
-macro_rules! assert_eq {
-    ($left:expr, $right:expr) => {{
-        let left = $left;
-        let right = $right;
-        $crate::assert!(
-            left == right,
-            "assertion failed: `(left == right)` \
-             \n  left: `{:?}`,\n right: `{:?}`",
-            left,
-            right)
-    }};
-    ($left:expr, $right:expr, $fmt:tt $($arg:tt)*) => {{
-        let left = $left;
-        let right = $right;
-        $crate::assert!(
-            left == right,
-            concat!(
-                "assertion failed: `(left == right)` \
-                 \n  left: `{:?}`, \n right: `{:?}`: ", $fmt),
-            left, right $($arg)*);
-    }};
-}
-
-#[macro_export]
-macro_rules! assert_ne {
-    ($left:expr, $right:expr) => {{
-        let left = $left;
-        let right = $right;
-        $crate::assert!(
-            left != right,
-            "assertion failed: `(left != right)` \
-             \n  left: `{:?}`,\n right: `{:?}`",
-            left,
-            right)
-    }};
-    ($left:expr, $right:expr, $fmt:tt $($arg:tt)*) => {{
-        let left = $left;
-        let right = $right;
-        $crate::assert!(
-            left != right,
-            concat!(
-                "assertion failed: `(left != right)` \
-                 \n  left: `{:?}`, \n right: `{:?}`: ", $fmt),
-            left, right $($arg)*);
-    }};
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
(this is a bit of a big one, sorry)

Added a prelude to verification-annotations to make it easier to import.

Added verifier module, that re-exports klee/seahorn, and moved shared code
from those modules to verifier.

Reimplemented verifier_nondet_bytes (not using klee_make_symbolic anymore).

Added a string module to propverify with strategies for generating an arbitrary
string with `n` bytes (doesn't work very well), and ascii string with `n`
bytes (works quite well with Klee).

Added demo/simple/string to test the new string module.