### PR TITLE
only sudo docker if not in docker group

### DIFF
--- a/docker/mkimage
+++ b/docker/mkimage
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source $(dirname "$(realpath -s "$0")")/sudo_if_needed.bash
+
 readonly DOCKER_IMAGE_NAME="$1"
 readonly DOCKER_FILE="$2"
 readonly DOCKER_VERSION="latest"
@@ -27,7 +29,7 @@ else
   KLEE_VERSION="c51ffcd377097ee80ec9b0d6f07f8ea583a5aa1d"
 fi
 
-sudo docker build \
+sudo_if_needed docker build \
   --file=${DOCKER_FILE} \
   --cache-from="${DOCKER_IMAGE_NAME}:${DOCKER_VERSION}" \
   --tag="${DOCKER_IMAGE_NAME}:${DOCKER_VERSION}" \

--- a/docker/run
+++ b/docker/run
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-readonly RVT_SRC=$(dirname $(realpath -s "$0"))/..
+source $(dirname "$(realpath -s "$0")")/sudo_if_needed.bash
+
+readonly RVT_SRC=$(dirname "$(realpath -s "$0")")/..
 readonly RVT_DST=/home/rust-verification-tools
 
 readonly MOUNT_PWD="type=bind,source=${PWD},target=${PWD}"
@@ -9,4 +11,4 @@ readonly MOUNT_RVT="type=bind,source=${RVT_SRC},target=${RVT_DST}"
 # based on https://dzone.com/articles/docker-x11-client-via-ssh
 readonly X11="--net=host --env=DISPLAY --volume=$HOME/.Xauthority:/home/$USER/.Xauthority:rw"
 
-sudo docker run --rm --mount ${MOUNT_RVT} --mount ${MOUNT_PWD} --workdir ${PWD} ${X11} -it rvt_r2ct:latest $*
+sudo_if_needed docker run --rm --mount ${MOUNT_RVT} --mount ${MOUNT_PWD} --workdir ${PWD} ${X11} -it rvt_r2ct:latest "$@"

--- a/docker/sudo_if_needed.bash
+++ b/docker/sudo_if_needed.bash
@@ -1,0 +1,12 @@
+# import this library with:
+#     source $(dirname "$(realpath -s "$0")")/sudo_if_needed.bash
+
+function sudo_if_needed() {
+    if [[ -w /var/run/docker.sock ]]; then
+        "$@"
+    else
+        echo "Running docker with sudo because you don't have write access to the docker socket."
+        echo "Add yourself to the docker group to avoid the need for this in future."
+        sudo "$@"
+    fi
+}


### PR DESCRIPTION
From the discussion on #139 and reading around, I suspect that it will be fine to skip using sudo if the user is able to write to the docker socket.

On linux, https://docs.docker.com/engine/install/linux-postinstall/
suggests creating a 'docker' group to avoid the need to sudo.
Most linux distributions do this for you, so all you need to
do is ensure that your user is in the docker group for passwordless
docker usage.

I also changed `$*` to `"$@"` and a few other changes that `shellcheck` proposed on lines that I was changing. I can do a full shellcheck sweep as a separate PR if you would like, following https://google.github.io/styleguide/shellguide.html