### PR TITLE
Fix register_dtor issue

### DIFF
--- a/runtime/src/atexit.c
+++ b/runtime/src/atexit.c
@@ -1,0 +1,11 @@
+int __cxa_atexit(void (*fn)(void*),
+                 void *arg,
+                 void *dso_handle) {
+  return 0;
+}
+
+// This variant is part of more recent glibc versions and
+// is required by the Rust standard library
+int __cxa_thread_atexit_impl(void (*fn)(void*), void *arg, void *dso_handle) {
+  return __cxa_atexit(fn, arg, dso_handle);
+}


### PR DESCRIPTION
Due to KLEE not supporting weak symbols, register_dtor (std/src/sys/unix/thread_local_dtor.rs) fails trying to invoke a symbolic function pointer instead of detecting that it is null and not invoking it.

This fixes the problem by defining the necessary symbol `__cxa_thread_atexit_impl`.
(It does not attempt to implement the full semantics of __cxa_atexit: we are mostly interested in bugs that occur before cleanup starts.)