### PR TITLE
Update mkimage

### DIFF
--- a/docker/mkimage
+++ b/docker/mkimage
@@ -31,6 +31,7 @@ fi
 
 sudo_if_needed docker build \
   --file=${DOCKER_FILE} \
+  --platform="linux/amd64" \
   --cache-from="${DOCKER_IMAGE_NAME}:${DOCKER_VERSION}" \
   --tag="${DOCKER_IMAGE_NAME}:${DOCKER_VERSION}" \
   --build-arg=USERNAME="$DOCKER_USER" \


### PR DESCRIPTION
Pin build to x86 since it is broken on ARM. Required for M1 users.