### PR TITLE
Add Github actions-based workflow to build and push Docker images

### DIFF
--- a/.github/workflows/build-push-docker-images.yaml
+++ b/.github/workflows/build-push-docker-images.yaml
@@ -12,14 +12,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        include:
-          - username: rvt
-            user_uid: 1000
-            user_gid: 1000
-            ubuntu_version: 20.04
-
     steps:
 
       - name: Checkout
@@ -40,10 +32,10 @@ jobs:
           context: docker/base
           push: true
           build-args: |
-            USERNAME=${{ matrix.username }}
-            USER_UID=${{ matrix.user_uid }}
-            USER_GID=${{ matrix.user_gid }}
-            UBUNTU_VERSION=${{ matrix.ubuntu_version }}
+            USERNAME=rvt
+            USER_UID=1000
+            USER_GID=1000
+            UBUNTU_VERSION=20.04
           cache-from: type=registry,ref=thierrymarianne/contrib-rvt_base:latest
           cache-to: type=inline
           tags: |
@@ -61,10 +53,6 @@ jobs:
       matrix:
         registry_namespace: ["thierrymarianne/"]
         image_prefix: [contrib-]
-        username: [rvt]
-        user_uid: [1000]
-        user_gid: [1000]
-        ubuntu_version: [20.04]
         google_test_version: [1.7.0]
         minisat_version: [37158a35c62d448b3feccfa83006266e12e5acb7]
         stp_version: [2.3.3]
@@ -105,7 +93,7 @@ jobs:
           push: true
           build-args: |
             FROM_IMAGE_FOR_SOLVERS=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_base:latest
-            USERNAME=${{ matrix.username }}
+            USERNAME=rvt
             MINISAT_VERSION=${{ matrix.minisat_version }}
             STP_VERSION=${{ matrix.stp_version }}
             YICES_VERSION=${{ matrix.yices_version }}
@@ -122,7 +110,7 @@ jobs:
           push: true
           build-args: |
             FROM_IMAGE_FOR_KLEE=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_solvers-llvm-${{ matrix.llvm }}:latest
-            USERNAME=${{ matrix.username }}
+            USERNAME=rvt
             GTEST_VERSION=${{ matrix.google_test_version }}
             LLVM_VERSION=${{ matrix.llvm }}
             KLEE_VERSION=${{ matrix.klee_version }}
@@ -139,7 +127,7 @@ jobs:
           push: true
           build-args: |
             FROM_IMAGE_FOR_SEAHORN=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_klee-llvm-${{ matrix.llvm }}:latest
-            USERNAME=${{ matrix.username }}
+            USERNAME=rvt
             LLVM_VERSION=${{ matrix.llvm }}
             KLEE_VERSION=${{ matrix.klee_version }}
             SEAHORN_VERIFY_C_COMMON_VERSION=${{ matrix.seahorn_verify_c_common_version }}
@@ -158,9 +146,9 @@ jobs:
           push: true
           build-args: |
             FROM_IMAGE_FOR_RVT=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_seahorn-llvm-${{ matrix.llvm }}:latest
-            USERNAME=${{ matrix.username }}
-            USER_UID=${{ matrix.user_uid }}
-            USER_GID=${{ matrix.user_gid }}
+            USERNAME=rvt
+            USER_UID=1000
+            USER_GID=1000
             RUSTC_VERSION=${{ matrix.rustc_version }}
           cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt-llvm-${{ matrix.llvm }}:latest
           cache-to: type=inline
@@ -174,9 +162,9 @@ jobs:
           push: true
           build-args: |
             FROM_IMAGE_FOR_RVT_R2CT=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt-llvm-${{ matrix.llvm }}:latest
-            USERNAME=${{ matrix.username }}
-            USER_UID=${{ matrix.user_uid }}
-            USER_GID=${{ matrix.user_gid }}
+            USERNAME=rvt
+            USER_UID=1000
+            USER_GID=1000
           cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_r2ct-llvm-${{ matrix.llvm }}:latest
           cache-to: type=inline
           tags: |

--- a/.github/workflows/build-push-docker-images.yaml
+++ b/.github/workflows/build-push-docker-images.yaml
@@ -1,0 +1,183 @@
+name: Build-Push-Docker-Image
+
+on:
+  push:
+    branches:
+      - build-push-docker-images
+
+jobs:
+  build-push-base-rvt-image:
+
+    name: Build and push RVT base Docker image
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - username: rvt
+            user_uid: 1000
+            user_gid: 1000
+            ubuntu_version: 20.04
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push rvt_base
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: docker/base
+          push: true
+          build-args: |
+            USERNAME=${{ matrix.username }}
+            USER_UID=${{ matrix.user_uid }}
+            USER_GID=${{ matrix.user_gid }}
+            UBUNTU_VERSION=${{ matrix.ubuntu_version }}
+          cache-from: type=registry,ref=thierrymarianne/contrib-rvt_base:latest
+          cache-to: type=inline
+          tags: |
+            thierrymarianne/contrib-rvt_base:latest
+
+  build-push-rvt-images:
+
+    needs: build-push-base-rvt-image
+
+    name: Build and push RVT solvers, Klee, SeaHorn, Rust2calltree images
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        registry_namespace: ["thierrymarianne/"]
+        image_prefix: [contrib-]
+        username: [rvt]
+        user_uid: [1000]
+        user_gid: [1000]
+        ubuntu_version: [20.04]
+        google_test_version: [1.7.0]
+        minisat_version: [37158a35c62d448b3feccfa83006266e12e5acb7]
+        stp_version: [2.3.3]
+        seahorn_verify_c_common_version: [70129bf47c421d8283785a8fb13cdb216424ef91]
+        seahorn_version: [ccdc529f81a02e9236ffa00ff57eef4487f0fc9a]
+        uclibc_version: [klee_uclibc_v1.2]
+        yices_version: [2.6.2]
+        z3_version: [4.8.7]
+        llvm: [10, 11]
+
+        include:
+          - llvm: 10
+            rustc_version: nightly-2020-08-03
+            klee_version: c51ffcd377097ee80ec9b0d6f07f8ea583a5aa1d
+
+          - llvm: 11
+            rustc_version: nightly-2021-02-20
+            klee_version: abdb0b650b8fce419dc5695e037557708f374021
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push solvers image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: ./docker/solvers
+          push: true
+          build-args: |
+            FROM_IMAGE_FOR_SOLVERS=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_base:latest
+            USERNAME=${{ matrix.username }}
+            MINISAT_VERSION=${{ matrix.minisat_version }}
+            STP_VERSION=${{ matrix.stp_version }}
+            YICES_VERSION=${{ matrix.yices_version }}
+            Z3_VERSION=${{ matrix.z3_version }}
+          cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_solvers-llvm-${{ matrix.llvm }}:latest
+          cache-to: type=inline
+          tags: |
+            ${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_solvers-llvm-${{ matrix.llvm }}:latest
+
+      - name: Build and push Klee image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: ./docker/klee
+          push: true
+          build-args: |
+            FROM_IMAGE_FOR_KLEE=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_solvers-llvm-${{ matrix.llvm }}:latest
+            USERNAME=${{ matrix.username }}
+            GTEST_VERSION=${{ matrix.google_test_version }}
+            LLVM_VERSION=${{ matrix.llvm }}
+            KLEE_VERSION=${{ matrix.klee_version }}
+            UCLIBC_VERSION=${{ matrix.uclibc_version }}
+          cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_klee-llvm-${{ matrix.llvm }}:latest
+          cache-to: type=inline
+          tags: |
+            ${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_klee-llvm-${{ matrix.llvm }}:latest
+
+      - name: Build and push SeaHorn image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: ./docker/seahorn
+          push: true
+          build-args: |
+            FROM_IMAGE_FOR_SEAHORN=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_klee-llvm-${{ matrix.llvm }}:latest
+            USERNAME=${{ matrix.username }}
+            LLVM_VERSION=${{ matrix.llvm }}
+            KLEE_VERSION=${{ matrix.klee_version }}
+            SEAHORN_VERIFY_C_COMMON_VERSION=${{ matrix.seahorn_verify_c_common_version }}
+            SEAHORN_VERSION=${{ matrix.seahorn_version }}
+            YICES_VERSION=${{ matrix.yices_version }}
+          cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_seahorn-llvm-${{ matrix.llvm }}:latest
+          cache-to: type=inline
+          tags: |
+            ${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_seahorn-llvm-${{ matrix.llvm }}:latest
+
+      - name: Build and push rvt image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: .
+          file: ./docker/rvt/Dockerfile
+          push: true
+          build-args: |
+            FROM_IMAGE_FOR_RVT=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_seahorn-llvm-${{ matrix.llvm }}:latest
+            USERNAME=${{ matrix.username }}
+            USER_UID=${{ matrix.user_uid }}
+            USER_GID=${{ matrix.user_gid }}
+            RUSTC_VERSION=${{ matrix.rustc_version }}
+          cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt-llvm-${{ matrix.llvm }}:latest
+          cache-to: type=inline
+          tags: |
+            ${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt-llvm-${{ matrix.llvm }}:latest
+
+      - name: Build and push rust2calltree image
+        uses: docker/build-push-action@v2.2.2
+        with:
+          context: ./docker/rust2calltree
+          push: true
+          build-args: |
+            FROM_IMAGE_FOR_RVT_R2CT=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt-llvm-${{ matrix.llvm }}:latest
+            USERNAME=${{ matrix.username }}
+            USER_UID=${{ matrix.user_uid }}
+            USER_GID=${{ matrix.user_gid }}
+          cache-from: type=registry,ref=${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_r2ct-llvm-${{ matrix.llvm }}:latest
+          cache-to: type=inline
+          tags: |
+            ${{ matrix.registry_namespace }}${{ matrix.image_prefix }}rvt_r2ct-llvm-${{ matrix.llvm }}:latest

--- a/docker/run
+++ b/docker/run
@@ -1,14 +1,91 @@
 #!/usr/bin/env bash
 
-source $(dirname "$(realpath -s "$0")")/sudo_if_needed.bash
+arguments=$@
 
-readonly RVT_SRC=$(dirname "$(realpath -s "$0")")/..
-readonly RVT_DST=/home/rust-verification-tools
+function run_rvt() {
+    local run_in_detached_mode
+    run_in_detached_mode="${DETACHED_MODE}"
 
-readonly MOUNT_PWD="type=bind,source=${PWD},target=${PWD}"
-readonly MOUNT_RVT="type=bind,source=${RVT_SRC},target=${RVT_DST}"
+    local help
+    help=''
 
-# based on https://dzone.com/articles/docker-x11-client-via-ssh
-readonly X11="--net=host --env=DISPLAY --volume=$HOME/.Xauthority:/home/$USER/.Xauthority:rw"
+    if [ "${arguments[0]}" == '--help' ];
+    then
+        help='Here are some tips:'
+        arguments=("${arguments[@]:1}")
+    fi
 
-sudo_if_needed docker run --rm --mount ${MOUNT_RVT} --mount ${MOUNT_PWD} --workdir ${PWD} ${X11} -it rvt_r2ct:latest "$@"
+    readonly RVT_SRC=$(dirname "$(realpath -s "$0")")/..
+    readonly RVT_DST=/home/rust-verification-tools
+
+    readonly MOUNT_PWD="type=bind,source=${PWD},target=${PWD}"
+    readonly MOUNT_RVT="type=bind,source=${RVT_SRC},target=${RVT_DST}"
+
+    # based on https://dzone.com/articles/docker-x11-client-via-ssh
+    readonly X11="--net=host --env=DISPLAY --volume=$HOME/.Xauthority:/home/$USER/.Xauthority:rw"
+
+    if [ -n "${help}" ];
+    then
+        echo ''
+        echo "${help}"
+        echo ''
+        echo '*  Mounting an additional directory *'
+        echo ''
+        echo 'A host directory can be bound to /source directory in the container'
+        echo 'by exporting a environment variable e.g.'
+        echo 'export MOUNT_SOURCE=/tmp/project'
+        echo ''
+        echo '*  Running RVT container in detached mode *'
+        echo ''
+        echo 'To run RVT container in detached mode'
+        echo 'DETACHED=true ./docker/run'
+        echo ''
+        echo 'To revert to the base behavior'
+        echo './docker/run'
+        echo ''
+        echo '*  Running RVT container from another image *'
+        echo ''
+        echo 'FROM_IMAGE_FOR_RVT_R2CT=custom-rvt-image:latest ./docker/run'
+        echo ''
+    fi
+
+    local source_mount
+    source_mount=''
+    if [ -n "${MOUNT_SOURCE}" ];
+    then
+        source_mount='--mount "type=bind,source=${MOUNT_SOURCE},target=/source"'
+    fi
+
+    local run_options
+    run_options="-ti "
+    if [ -n "${run_in_detached_mode}" ];
+    then
+        run_options="-d "
+    fi
+
+    if [ -z "${FROM_IMAGE_FOR_RVT_R2CT}" ];
+    then
+        FROM_IMAGE_FOR_RVT_R2CT='rvt_r2ct:latest'
+    fi
+
+    local source_location
+    source_location="$(dirname "$(realpath -s "$0")")"
+
+    local command
+    command="source ${source_location}/sudo_if_needed.bash && \
+    sudo_if_needed docker run --rm ${run_options}\
+        ${source_mount} \
+        --mount ${MOUNT_RVT} \
+        --mount ${MOUNT_PWD} \
+        --workdir ${PWD} ${X11} \
+        ${FROM_IMAGE_FOR_RVT_R2CT} ""${arguments}"
+
+    if [ -n "${DEBUG}" ];
+    then
+        echo 'About to run command:'
+        echo "${command}"
+    fi
+
+    /bin/bash -c "${command}"
+}
+run_rvt


### PR DESCRIPTION
Hello,

This is a proposal to have the Docker images built regularly 
(or on push to git branches following a specific pattern as needed)
so that they can be pulled from a registry by anyone 
who would like to run the rust verification tools 
(provided they'd be better off downloading images from a registry
instead of having to build them, which could be argued against as the resulting images are pretty heavy:
[~1.7 GB after compression](https://hub.docker.com/layers/161570518/thierrymarianne/contrib-rvt_r2ct-llvm-10/latest/images/sha256-4653e38083b81566e2c699c2b01b390f8bef741865b7de9284daa8bd4ced2468?context=repo) according to Docker registry).

More details about this pull-request can be found in this [issue](https://github.com/project-oak/rust-verification-tools/issues/150)

# Pre-merge requirements

 - [x] Remove user_uid, user_gid, username and ubuntu version params from matrix definition 
 - [ ] Replacing the target docker image names in the GitHub action configuration file :
   - for [rust base image](https://github.com/project-oak/rust-verification-tools/blob/290f2dc3ceb62399ca4036f730d529f419a876b3/.github/workflows/build-push-docker-images.yaml#L47-L50)
   - for [all other images](https://github.com/project-oak/rust-verification-tools/blob/290f2dc3ceb62399ca4036f730d529f419a876b3/.github/workflows/build-push-docker-images.yaml#L62-L63)
  - [ ] Having the maintainers declared `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` values in the project settings
  Docker hub tokens can be generated from https://hub.docker.com/settings/security
