### PR TITLE
Add rudimentary support for the SMACK verifier

### DIFF
--- a/cargo-verify/src/smack.rs
+++ b/cargo-verify/src/smack.rs
@@ -1,0 +1,83 @@
+// Copyright 2020-2021 The Propverify authors
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::{ffi::OsString, fs, path::Path, process::Command};
+
+use log::{info, warn};
+
+use crate::{utils::Append, *};
+
+/// Check if SMACK is available.
+pub fn check_install() -> bool {
+    let output = Command::new("which").arg("smack").output().ok();
+
+    match output {
+        Some(output) => output.status.success(),
+        None => false,
+    }
+}
+
+/// Run SMACK
+pub fn verify(opt: &Opt, name: &str, entry: &str, bcfile: &Path) -> CVResult<Status> {
+    let out_dir = opt.cargo_toml.with_file_name("smackout").append(name);
+
+    // Ignoring result. We don't care if it fails because the path doesn't
+    // exist.
+    fs::remove_dir_all(&out_dir).unwrap_or_default();
+    if out_dir.exists() {
+        Err(format!(
+            "Directory or file '{}' already exists, and can't be removed",
+            out_dir.to_string_lossy()
+        ))?
+    }
+    fs::create_dir_all(&out_dir)?;
+
+    info!("     Running SMACK to verify {}", name);
+    info!("      file: {}", bcfile.to_string_lossy());
+    info!("      entry: {}", entry);
+    info!("      results: {}", out_dir.to_string_lossy());
+
+    run(&opt, &name, &entry, &bcfile, &out_dir)
+}
+
+/// Run Smack and analyse its output.
+fn run(opt: &Opt, name: &str, entry: &str, bcfile: &Path, out_dir: &Path) -> CVResult<Status> {
+    let mut cmd = Command::new("smack");
+
+    let user_flags: Vec<_> = opt
+        .backend_flags
+        .iter()
+        .map(|flag| backends_common::format_flag(&flag, &entry, &bcfile, &out_dir))
+        .collect::<Result<_, _>>()?;
+
+    cmd.arg("--verifier=boogie")
+        .args(user_flags)
+        .arg(String::from("--entry-points=") + entry)
+        .arg(bcfile);
+    let (stdout, stderr, _) = cmd.output_info_ignore_exit(&opt, Verbosity::Major)?;
+
+    // Scan for result mesage
+    let status = stderr
+        .lines()
+        .chain(stdout.lines())
+        .find_map(|l| {
+            if l.starts_with("SMACK found no errors") {
+                Some(Status::Verified)
+            } else if l.starts_with("SMACK found an error") {
+                Some(Status::Error)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| {
+            warn!("Unable to determine status of {}", name);
+            Status::Unknown
+        });
+
+    Ok(status)
+}

--- a/compatibility-test/Cargo.toml
+++ b/compatibility-test/Cargo.toml
@@ -19,3 +19,4 @@ proptest = { version = "*" }
 [features]
 verifier-klee = ["propverify/verifier-klee"]
 verifier-crux = ["propverify/verifier-crux"]
+verifier-smack = ["propverify/verifier-smack"]

--- a/docker/build
+++ b/docker/build
@@ -18,6 +18,7 @@ set -e
 (cd docker/solvers && ../mkimage rvt_solvers    Dockerfile)
 (cd docker/klee    && ../mkimage rvt_klee       Dockerfile)
 (cd docker/seahorn && ../mkimage rvt_seahorn    Dockerfile)
+(cd docker/smack   && ../mkimage rvt_smack      Dockerfile)
 
 # This does not run in a subdirectory so it will copy everything over.
 # This is really unfortunate but it allows us to run docker/init

--- a/docker/init
+++ b/docker/init
@@ -5,6 +5,7 @@ set -e
 # Build libraries
 make -C ${RVT_DIR}/runtime TGT=klee
 make -C ${RVT_DIR}/runtime TGT=seahorn
+make -C ${RVT_DIR}/runtime TGT=smack
 make -C ${RVT_DIR}/simd_emulation
 
 # Build tools

--- a/docker/mkimage
+++ b/docker/mkimage
@@ -20,7 +20,8 @@ readonly DOCKER_USER="${USER:-root}"
 readonly FROM_IMAGE_FOR_SOLVERS=${FROM_IMAGE_FOR_SOLVERS:-rvt_base:latest}
 readonly FROM_IMAGE_FOR_KLEE=${FROM_IMAGE_FOR_KLEE:-rvt_solvers:latest}
 readonly FROM_IMAGE_FOR_SEAHORN=${FROM_IMAGE_FOR_SEAHORN:-rvt_klee:latest}
-readonly FROM_IMAGE_FOR_RVT=${FROM_IMAGE_FOR_RVT:-rvt_seahorn:latest}
+readonly FROM_IMAGE_FOR_SMACK=${FROM_IMAGE_FOR_SMACK:-rvt_seahorn:latest}
+readonly FROM_IMAGE_FOR_RVT=${FROM_IMAGE_FOR_RVT:-rvt_smack:latest}
 readonly FROM_IMAGE_FOR_RVT_R2CT=${FROM_IMAGE_FOR_RVT_R2CT:-rvt:latest}
 
 if [ -v LLVM11 ]; then
@@ -42,6 +43,7 @@ sudo_if_needed docker build \
   --build-arg=FROM_IMAGE_FOR_SOLVERS="$FROM_IMAGE_FOR_SOLVERS" \
   --build-arg=FROM_IMAGE_FOR_KLEE="$FROM_IMAGE_FOR_KLEE" \
   --build-arg=FROM_IMAGE_FOR_SEAHORN="$FROM_IMAGE_FOR_SEAHORN" \
+  --build-arg=FROM_IMAGE_FOR_SMACK="$FROM_IMAGE_FOR_SMACK" \
   --build-arg=FROM_IMAGE_FOR_RVT="$FROM_IMAGE_FOR_RVT" \
   --build-arg=FROM_IMAGE_FOR_RVT_R2CT="$FROM_IMAGE_FOR_RVT_R2CT" \
   --build-arg=USERNAME="$DOCKER_USER" \

--- a/docker/rvt/Dockerfile
+++ b/docker/rvt/Dockerfile
@@ -50,5 +50,5 @@ ENV PATH="${PATH}:${RVT_DIR}/scripts"
 ENV PATH="${PATH}:${RVT_DIR}/scripts/bin"
 
 # Create a bashrc file
-RUN echo "export PATH=\"${PATH}\"" >> ${USER_HOME}/.bashrc \
+RUN echo "export PATH=\"${PATH}\":\${PATH}" >> ${USER_HOME}/.bashrc \
   && echo "ulimit -c0" >> ${USER_HOME}/.bashrc

--- a/docker/smack/Dockerfile
+++ b/docker/smack/Dockerfile
@@ -1,0 +1,30 @@
+ARG FROM_IMAGE_FOR_SMACK
+FROM ${FROM_IMAGE_FOR_SMACK}
+
+USER root
+RUN apt-get update && \
+      apt-get -y install \
+      software-properties-common \
+      wget \
+      sudo \
+      g++
+
+# get repo
+USER ${USERNAME}
+WORKDIR ${USER_HOME}
+
+ENV SMACK_DIR=${USER_HOME}/smack
+
+RUN git clone --no-checkout https://github.com/smackers/smack.git ${SMACK_DIR} \
+  && cd ${SMACK_DIR} \
+  && git checkout develop
+
+# build and install smack
+
+ENV INSTALL_Z3=0
+ENV TEST_SMACK=0
+ENV INSTALL_RUST=0
+
+RUN cd ${SMACK_DIR} && bin/build.sh --prefix ${SMACK_DIR}/smack-install
+
+RUN echo "source ${USER_HOME}/smack.environment" >> ${USER_HOME}/.bashrc

--- a/propverify/Cargo.toml
+++ b/propverify/Cargo.toml
@@ -19,7 +19,7 @@ float = []
 verifier-klee = [ "verification-annotations/verifier-klee", "float" ]
 verifier-crux = [ "verification-annotations/verifier-crux" ]
 verifier-seahorn = [ "verification-annotations/verifier-seahorn" ]
-
+verifier-smack = [ "verification-annotations/verifier-smack" ]
 
 [dependencies]
 verification-annotations = { path = "../verification-annotations" }

--- a/rvt-patch-llvm/src/main.rs
+++ b/rvt-patch-llvm/src/main.rs
@@ -61,6 +61,10 @@ struct Opt {
     #[structopt(long, conflicts_with = "initializers")]
     seahorn: bool,
 
+    /// Smack
+    #[structopt(long)]
+    smack: bool,
+
     /// Increase message verbosity
     #[structopt(short, long, parse(from_occurrences))]
     verbosity: usize,
@@ -143,6 +147,27 @@ fn main() {
 
         handle_panic(&context, &module);
 
+        replace_def_with_dec(
+            &module,
+            &Regex::new(r"^_ZN3std2io5stdio7_eprint17h[a-f0-9]{16}E$").unwrap(),
+        );
+        replace_def_with_dec(
+            &module,
+            &Regex::new(r"^_ZN3std2io5stdio6_print17h[a-f0-9]{16}E$").unwrap(),
+        );
+    }
+
+    if opt.smack {
+        handle_main(&module);
+
+        replace_def_with_dec(
+            &module,
+            &Regex::new(r"^__VERIFIER_(assume|assert)$").unwrap(),
+        );
+        replace_def_with_dec(
+            &module,
+            &Regex::new(r"^__VERIFIER_nondet_[iu]\d+$").unwrap(),
+        );
         replace_def_with_dec(
             &module,
             &Regex::new(r"^_ZN3std2io5stdio7_eprint17h[a-f0-9]{16}E$").unwrap(),

--- a/verification-annotations/Cargo.toml
+++ b/verification-annotations/Cargo.toml
@@ -17,6 +17,7 @@ std = []
 verifier-crux = []
 verifier-klee = []
 verifier-seahorn = [ "cc" ]
+verifier-smack = [ "cc" ]
 
 [build-dependencies]
 cc = { optional = true, version = "1.0" }

--- a/verification-annotations/build.rs
+++ b/verification-annotations/build.rs
@@ -10,10 +10,21 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     #[cfg(feature = "verifier-seahorn")]
     seahorn();
+    #[cfg(feature = "verifier-smack")]
+    smack();
 }
 
 #[cfg(feature = "verifier-seahorn")]
 fn seahorn() {
     println!("cargo:rerun-if-changed=lib/seahorn.c");
     cc::Build::new().file("lib/seahorn.c").compile("seahorn");
+}
+
+#[cfg(feature = "verifier-smack")]
+fn smack() {
+    println!("cargo:rerun-if-changed=lib/smack-rust.c");
+    cc::Build::new()
+        .file("lib/smack-rust.c")
+        .define("CARGO_BUILD", None)
+        .compile("smack");
 }

--- a/verification-annotations/lib/smack-rust.c
+++ b/verification-annotations/lib/smack-rust.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#define mk_signed_type(size) int##size##_t
+#define mk_unsigned_type(size) uint##size##_t
+
+#define mk_signed_min(size) INT##size##_MIN
+#define mk_signed_max(size) INT##size##_MAX
+#define mk_unsigned_min(size) 0
+#define mk_unsigned_max(size) UINT##size##_MAX
+
+#define mk_smack_signed_nondet(size) __SMACK_nondet_i##size
+#define mk_smack_unsigned_nondet(size) __SMACK_nondet_u##size
+#define mk_smack_nondet_decl(size)                                             \
+  mk_signed_type(size) mk_smack_signed_nondet(size)(void);                     \
+  mk_unsigned_type(size) mk_smack_unsigned_nondet(size)(void);
+
+#define mk_smack_nondet_def(size)                                              \
+  mk_signed_type(size) __VERIFIER_nondet_i##size(void) {                       \
+    mk_signed_type(size) ret = mk_smack_signed_nondet(size)();                 \
+    if (ret < mk_signed_min(size) || ret > mk_signed_max(size))                \
+      abort();                                                                 \
+    return ret;                                                                \
+  }                                                                            \
+  mk_unsigned_type(size) __VERIFIER_nondet_u##size(void) {                     \
+    mk_unsigned_type(size) ret = mk_smack_unsigned_nondet(size)();             \
+    if (ret < mk_unsigned_min(size) || ret > mk_unsigned_max(size))            \
+      abort();                                                                 \
+    return ret;                                                                \
+  }
+
+#define mk_dummy_int_nondet_def(size)                                          \
+  mk_signed_type(size) __VERIFIER_nondet_i##size(void) {                       \
+    return *((mk_signed_type(size) *)malloc(sizeof(mk_signed_type(size))));    \
+  }                                                                            \
+  mk_unsigned_type(size) __VERIFIER_nondet_u##size(void) {                     \
+    return *(                                                                  \
+        (mk_unsigned_type(size) *)malloc(sizeof(mk_unsigned_type(size))));     \
+  }
+
+#define mk_dummy_fp_nondet_def(ty)                                             \
+  ty __VERIFIER_nondet_##ty(void) { return *((ty *)malloc(sizeof(ty))); }
+
+#if CARGO_BUILD
+mk_dummy_int_nondet_def(8) mk_dummy_int_nondet_def(16)
+    mk_dummy_int_nondet_def(32) mk_dummy_int_nondet_def(64)
+        mk_dummy_fp_nondet_def(float)
+            mk_dummy_fp_nondet_def(double) void __VERIFIER_assert(int x) {}
+void __VERIFIER_assume(int x) {}
+#else
+mk_smack_nondet_decl(8) mk_smack_nondet_decl(16) mk_smack_nondet_decl(32)
+    mk_smack_nondet_decl(64) mk_smack_nondet_def(8) mk_smack_nondet_def(16)
+        mk_smack_nondet_def(32) mk_smack_nondet_def(64)
+#endif

--- a/verification-annotations/src/tests.rs
+++ b/verification-annotations/src/tests.rs
@@ -14,7 +14,11 @@ fn t0() {
     verifier::assume(4 <= a && a <= 7);
     verifier::assume(5 <= b && b <= 8);
 
-    #[cfg(not(any(feature = "verifier-crux", feature = "verifier-seahorn")))]
+    #[cfg(not(any(
+        feature = "verifier-crux",
+        feature = "verifier-seahorn",
+        feature = "verifier-smack"
+    )))]
     if verifier::is_replay() {
         eprintln!("Test values: a = {}, b = {}", a, b)
     }

--- a/verification-annotations/src/verifier/mod.rs
+++ b/verification-annotations/src/verifier/mod.rs
@@ -30,6 +30,11 @@ mod seahorn;
 #[cfg(feature = "verifier-seahorn")]
 pub use seahorn::*;
 
+#[cfg(feature = "verifier-smack")]
+mod smack;
+#[cfg(feature = "verifier-smack")]
+pub use smack::*;
+
 #[cfg(feature = "std")]
 /// Allocate a symbolic vector of bytes
 pub fn verifier_nondet_bytes(n: usize) -> Vec<u8> {
@@ -84,10 +89,13 @@ macro_rules! assert {
     ($cond:expr) => { $crate::verifier::assert!($cond, "assertion failed: {}", stringify!($cond)) };
     ($cond:expr, $($arg:tt)+) => {{
         if ! $cond {
-            let message = format!($($arg)+);
-            eprintln!("VERIFIER: panicked at '{}', {}:{}:{}",
-                      message,
-                      std::file!(), std::line!(), std::column!());
+	    #[cfg(not(feature = "verifier-smack"))]
+	    {
+		let message = format!($($arg)+);
+		eprintln!("VERIFIER: panicked at '{}', {}:{}:{}",
+			  message,
+			  std::file!(), std::line!(), std::column!());
+	    }
             $crate::verifier::abort();
         }
     }}


### PR DESCRIPTION
Hello,

This adds rudimentary support for the SMACK verifier (https://github.com/smackers/smack) for use with the `verification-annotations` package. This includes installation of the tool and support for the verification annotations.

Currently, SMACK can run on the `t0`, `t1` and `t2` tests, but needs more work to not crash on the others. 